### PR TITLE
Rename our core stakeholders to "participants" (from "users")

### DIFF
--- a/content/guides/overview.md
+++ b/content/guides/overview.md
@@ -1,6 +1,7 @@
 ---
 title: Protocol Overview
 summary: An introduction to the AT Protocol.
+
 ---
 
 # Protocol Overview
@@ -9,13 +10,13 @@ The **Authenticated Transfer Protocol**, aka **ATP**, is a protocol for large-sc
 
 ## Identity
 
-Users are identified by domain names in AT Protocol. These domains map to cryptographic URLs which secure the user's account and its data.
+Participants are identified by domain names in AT Protocol. These domains map to cryptographic URLs which secure the participant's account and its data.
 
 ![Identities](/img/identities.jpg)
 
 ## Data repositories
 
-User data is exchanged in [signed data repositories](/guides/data-repos). These repositories are collections of records which include posts, comments, likes, follows, media blobs, etc.
+Participant data is exchanged in [signed data repositories](/guides/data-repos). These repositories are collections of records which include posts, comments, likes, follows, media blobs, etc.
 
 ![Data repos](/img/data-repos.jpg)
 
@@ -27,7 +28,7 @@ ATP syncs the repositories in a federated networking model. Federation was chose
 
 ## Interoperation
 
-A global schemas network called [Lexicon](/specs/lexicon) is used to unify the names and behaviors of the calls across the servers. Servers implement "lexicons" to support featuresets, including the core [ATP Lexicon](/lexicons/atproto-com) for syncing user repositories and the [Bsky Lexicon](/lexicons/bsky-app) to provide basic social behaviors.
+A global schemas network called [Lexicon](/specs/lexicon) is used to unify the names and behaviors of the calls across the servers. Servers implement "lexicons" to support featuresets, including the core [ATP Lexicon](/lexicons/atproto-com) for syncing participant repositories and the [Bsky Lexicon](/lexicons/bsky-app) to provide basic social behaviors.
 
 ![Interop](/img/interop.jpg)
 
@@ -37,39 +38,39 @@ While the Web exchanges documents, the AT Protocol exchanges schematic and seman
 
 ATP distinguishes between "small-world" vs "big-world" networking. *Small-world* networking encompass inter-personal activity while *big-world* networking aggregates activity outside of the user's personal interactions. 
 
-* **Small-world**: delivery of events targeted at specific users such as mentions, replies, and DMs, and sync of datasets according to follow graphs.
-* **Big-world**: large-scale metrics (likes, reposts, followers), content discovery (algorithms), and user search.
+* **Small-world**: delivery of events targeted at specific participants such as mentions, replies, and DMs, and sync of datasets according to follow graphs.
+* **Big-world**: large-scale metrics (likes, reposts, followers), content discovery (algorithms), and participant search.
 
 Personal Data Servers (PDS) are responsible for small-world networking while indexing services separately crawl the network to provide big-world networking.
 
 ![Small world, Big world](/img/small-big-world.jpg)
 
-The small-world/big-world distinction is intended to achieve scale as well as a high degree of user-choice. 
+The small-world/big-world distinction is intended to achieve scale as well as a high degree of customization.
 
 ## Algorithmic choice
 
-As with Web search engines, users are free to select their indexers. Each feed, discovery section, or search interface is integrated into the PDS while being served from a third party service.
+As with Web search engines, participants are free to select their indexers. Each feed, discovery section, or search interface is integrated into the PDS while being served from a third party service.
 
 ![Algorithmic choice](/img/algorithmic-choice.jpg)
 
 ## Account portability
 
-We assume that a Personal Data Server may fail at any time, either by going offline in its entirety or by ceasing service for specific users. ATP's goal is to ensure that a user can migrate their account to a new PDS without the server's involvement.
+We assume that a Personal Data Server may fail at any time, either by going offline in its entirety or by ceasing service for specific participants. ATP's goal is to ensure that a participant can migrate their account to a new PDS without the server's involvement.
 
-User data is stored in [signed data repositories](/guides/data-repos) and verified by [DIDs](/guides/identity). DIDs are essentially registries of user certificates, similar in some ways to the TLS certificate system. They are expected to be secure, reliable, and independent of the users' PDS.
+Participant data is stored in [signed data repositories](/guides/data-repos) and verified by [DIDs](/guides/identity). DIDs are essentially registries of participant certificates, similar in some ways to the TLS certificate system. They are expected to be secure, reliable, and independent of the participants' PDS.
 
 ![DID Documents](/img/did-doc.jpg)
 
 Each DID Document publishes two public keys: a signing key and a recovery key.
 
-* **Signing key**: Asserts changes to the DID Document *and* to the user's data repository.
+* **Signing key**: Asserts changes to the DID Document *and* to the participant's data repository.
 * **Recovery key**: Asserts changes to the DID Document; may override the signing key within a 72-hour window.
 
-The signing key is entrusted to the PDS so that it can manage the user's data, but the recovery key is saved by the user, eg as a paper key. This makes it possible for the user to update their account to a new PDS without the original host's help.
+The signing key is entrusted to the PDS so that it can manage the participant's data, but the recovery key is saved by the participant, e.g. as a paper key. This makes it possible for the participant to update their account to a new PDS without the original host's help.
 
 ![Account recovery](/img/recovery.jpg)
 
-A backup of the user’s data is persistently synced to their client as a backup (contingent on the disk space available). Should a PDS disappear without notice, the user should be able to migrate to a new provider by updating their DID Document and uploading the backup.
+A backup of the participant’s data is persistently synced to their client as a backup (contingent on the disk space available). Should a PDS disappear without notice, the participant should be able to migrate to a new provider by updating their DID Document and uploading the backup.
 
 ## Speech, reach, and moderation
 


### PR DESCRIPTION
# Motivation

Many software projects name their customers as "users" and it seems this is from inertia rather than thoughtful consideration. I hope we can be more intentional with how we refer to the people that are using AT Protocol and this issue is for people also interested in the cause. I couldn't find the mission statement for the AT Protocol, but I assume it's something like "Social media must be resilient to corporate and government control, and empower the agency of the original author" ([inspiration](https://www.getrevue.co/profile/jackjack/issues/a-native-internet-protocol-for-social-media-1503112?via=twitter-card&client=DesktopWeb&element=issue-card#)). If so, this issue is in project scope whereas it helps further respect the agency of the original author.

The basic problems with the word choice "user" are:

1. **It is not descriptive**—*user* means lots of things, even in the context of a software project, the protocol producers and consumers, the humans behind it, robots, the server and other servers, the cron jobs, every part of the software itself can all be called users.
2. **Not human enough**—typically with software, we are imagining ways that a computer can serve a human, let's use more human words to describe the customers then. Are they publishers or readers? Let's call them that. Is this a community? Let's find some inspiration from that.
3. **"User" subjugates the customer's interests below the product's interests**—I have recently come to appreciate why you should call Bob as "looking for a house" or "displaced" or some of the other words people use today, rather than "a homeless person". Because Bob is not defined by his not having a home, that is a poor description for a person. Also, when "a homeless person" moves into a home they die (literally *and* figuratively, because the subject is figurative). Instead, let's choose names/words from the customer's perspective in a way that respects their interests.

# Background

Many people/agents will be using AT Protocol, including:

1. people/entities that publish content
1. people/entities that consume content
1. software agents that work on the behalf of 1 and 2
1. servers that provide storage and execution of the protocol
1. transport agents that connect to the servers, but not necessarily initiated by the command of 1 and 2
1. other things we have not dreamed up yet

# Ideas instead of "users"

- Participants
- Members
- Publishers
- Syndicates

And if we need to separate producers and consumers of the protocol, we can refer to the humans with agency as "publishers and readers" eschewing a single word.

---

This PR changes the word for the top file, and with permission/invitation I'm committing to update all the documentation to match.