### PR TITLE
Fix a few doc typos

### DIFF
--- a/content/guides/identity.md
+++ b/content/guides/identity.md
@@ -24,7 +24,7 @@ Adopting this system should give applications the tools for end-to-end encryptio
 
 We use two interrelated forms of identifiers: the _handle_ and the _DID_. Handles are DNS names while DIDs are an [emerging W3C standard](https://www.w3.org/TR/did-core/) which act as secure & stable IDs.
 
-The following are all valid user identifers:
+The following are all valid user identifiers:
 
 <pre><code>@alice.host.com
 at://alice.host.com
@@ -94,7 +94,7 @@ At present, none of the DID methods meet our standards fully. **Therefore we hav
 
 Handles in ATP are domain names which resolve to a DID, which in turn resolves to a DID Document containing the user's signing pubkey and hosting service.
 
-Handle resolution uses the [`com.atproto.handle.resolve`](/lexicons/com-atproto-handle) xrpc method. The method call should be sent to the server identified by the handle, and the handle should be passed as a parameter.
+Handle resolution uses the [`com.atproto.handle.resolve`](/lexicons/com-atproto-handle) XRPC method. The method call should be sent to the server identified by the handle, and the handle should be passed as a parameter.
 
 Here is the algorithm in pseudo-typescript:
 

--- a/content/guides/lexicon.md
+++ b/content/guides/lexicon.md
@@ -278,4 +278,4 @@ If a schema must change a previously-published constraint, it should be publishe
 
 Schemas are designed to be machine-readable and network-accessible. While it is not currently _required_ that a schema is available on the network, it is strongly advised to publish schemas so that a single canonical & authoritative representation is available to consumers of the method.
 
-To fetch a schema, a request is sent via the xrpc [`getSchema`](/specs/xrpc#getschema) method. This request is sent to the authority of the NSID.
+To fetch a schema, a request is sent via the XRPC [`getSchema`](/specs/xrpc#getschema) method. This request is sent to the authority of the NSID.

--- a/content/guides/overview.md
+++ b/content/guides/overview.md
@@ -89,7 +89,7 @@ Five primary specs comprise the v1 of the @-protocol. These specs are:
 - [NameSpaced IDs (NSIDs)](/specs/nsid)
 - [DID:Placeholder (did:plc)](/specs/did-plc)
 
-These specs can be organize into three layers of dependency:
+These specs can be organized into three layers of dependency:
 
 ![Spec diagram](/img/spec-diagram.jpg)
 

--- a/content/specs/atp.md
+++ b/content/specs/atp.md
@@ -41,7 +41,7 @@ wip: true
 
 ## Wire protocol (XRPC)
 
-ATP uses a light wrapper over HTTPS called [XRPC](./xrpc). XRPC uses [Lexicon](./lexicon), a global schema system, to unify behaviors across hosts. The atproto.com lexicons enumerate all xrpc methods used in ATP.
+ATP uses a light wrapper over HTTPS called [XRPC](./xrpc). XRPC uses [Lexicon](./lexicon), a global schema system, to unify behaviors across hosts. The atproto.com lexicons enumerate all XRPC methods used in ATP.
 
 ## Identifiers
 
@@ -110,7 +110,7 @@ A "repository" is a collection of signed records.
 
 It is an implementation of a [Merkle Search Tree (MST)](https://hal.inria.fr/hal-02303490/document). The MST is an ordered, insert-order-independent, deterministic tree. Keys are laid out in alphabetic order. The key insight of an MST is that each key is hashed and starting 0s are counted to determine which layer it falls on (5 zeros for ~32 fanout).
 
-This is a merkle tree, so each subtree is referred to by it's hash (CID). When a leaf is changed, ever tree on the path to that leaf is changed as well, thereby updating the root hash.
+This is a Merkle tree, so each subtree is referred to by its hash (CID). When a leaf is changed, every tree on the path to that leaf is changed as well, thereby updating the root hash.
 
 ### Repo data layout
 
@@ -118,7 +118,7 @@ This is a merkle tree, so each subtree is referred to by it's hash (CID). When a
   Provide a more detailed description of the data layout and how the MST is organized.
 </div>
 
-The repository data layout establishes the units of network-transmissable data. It includes the following three major groupings:
+The repository data layout establishes the units of network-transmissible data. It includes the following three major groupings:
 
 |Grouping|Description|
 |-|-|

--- a/content/specs/did-plc.md
+++ b/content/specs/did-plc.md
@@ -51,7 +51,7 @@ To illustrate:
 
 Operations are verified, ordered, and made available by the PLC server. 
 
-The PLC server is contrained in its capabilities.
+The PLC server is constrained in its capabilities.
 The operation logs are fully self-certifying, with the exception of their ordering.
 
 Therefore, the PLC server's attacks are limited to:

--- a/content/specs/lexicon.md
+++ b/content/specs/lexicon.md
@@ -68,7 +68,7 @@ interface LexRecord extends LexUserType {
   record: LexObject
 }
 
-// xrpc
+// XRPC
 // =
 
 interface LexXrpcQuery extends LexUserType {

--- a/content/specs/xrpc.md
+++ b/content/specs/xrpc.md
@@ -80,7 +80,7 @@ Method schemas are encoded in JSON using [Lexicon Schema Documents](./lexicon).
 
 #### Schema distribution
 
-Method schemas are designed to be machine-readable and network-accessible. While it is not current _required_ that a schema is available on the network, it is strongly advised to publish schemas so that a single canonical & authoritative representation is available to consumers of the method.
+Method schemas are designed to be machine-readable and network-accessible. While it is not currently _required_ that a schema is available on the network, it is strongly advised to publish schemas so that a single canonical & authoritative representation is available to consumers of the method.
 
 To fetch a schema, a request must be sent to the builtin [`getSchema`](#getschema) method. This request is sent to the authority of the NSID.
 


### PR DESCRIPTION
Spotted a small number of typos while working through the docs and figured I'd fix 'em while I was looking.