### PR TITLE
Fixing documentation links for atproto-com

### DIFF
--- a/content/guides/overview.md
+++ b/content/guides/overview.md
@@ -27,7 +27,7 @@ ATP syncs the repositories in a federated networking model. Federation was chose
 
 ## Interoperation
 
-A global schemas network called [Lexicon](/specs/lexicon) is used to unify the names and behaviors of the calls across the servers. Servers implement "lexicons" to support featuresets, including the core [ATP Lexicon](/lexicons/atproto-com) for syncing user repositories and the [Bsky Lexicon](/lexicons/bsky-app) to provide basic social behaviors.
+A global schemas network called [Lexicon](/specs/lexicon) is used to unify the names and behaviors of the calls across the servers. Servers implement "lexicons" to support featuresets, including the core [ATP Lexicon](/lexicons/com-atproto-identity) for syncing user repositories and the [Bsky Lexicon](/lexicons/app-bsky-actor) to provide basic social behaviors.
 
 ![Interop](/img/interop.jpg)
 

--- a/content/specs/atp.md
+++ b/content/specs/atp.md
@@ -255,7 +255,7 @@ ATP uses dollar (`$`) prefixed fields as system fields. The following fields are
 
 ## Client-to-server API
 
-The client-to-server API drives communication between a client application and the user's PDS. The APIs are dictated by the lexicons implemented by the PDS. It's recommended that every PDS support the full [atproto.com lexicon](/lexicons/atproto-com). Application-level lexicons such as [bsky.app](/lexicons/bsky-app) are also recommended.
+The client-to-server API drives communication between a client application and the user's PDS. The APIs are dictated by the lexicons implemented by the PDS. It's recommended that every PDS support the full [atproto.com lexicon](/lexicons/com-atproto-identity). Application-level lexicons such as [bsky.app](/lexicons/app-bsky-actor) are also recommended.
 
 ### Authentication
 

--- a/next.config.js
+++ b/next.config.js
@@ -26,7 +26,7 @@ const nextConfig = {
       // legacy docs
       {
         source: '/lexicons/atproto-com',
-        destination: '/lexicons/com-atproto-account',
+        destination: '/lexicons/com-atproto-identity',
         permanent: false,
       },
       {


### PR DESCRIPTION
`/lexicons/com-atproto` is a broken link ([see here](https://atproto.com/lexicons/com-atproto)), so changed references to `/lexicons/com-atproto-identity`.

Your next.config.js should handle the redirect, but I suspect that because `/lexicons/com-atproto-account` is _also_ not a valid path that this isn't working.

Included a docs update for the active/valid `/lexicons/app-bsky-actor` link as well.