### PR TITLE
Update Lexicons

### DIFF
--- a/content/lexicons/app-bsky-actor.md
+++ b/content/lexicons/app-bsky-actor.md
@@ -38,7 +38,8 @@ A reference to an actor in the network.
         },
         "displayName": {
           "type": "string",
-          "maxLength": 64
+          "maxGraphemes": 64,
+          "maxLength": 640
         },
         "avatar": {
           "type": "string"
@@ -46,6 +47,13 @@ A reference to an actor in the network.
         "viewer": {
           "type": "ref",
           "ref": "#viewerState"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "com.atproto.label.defs#label"
+          }
         }
       }
     },
@@ -66,11 +74,13 @@ A reference to an actor in the network.
         },
         "displayName": {
           "type": "string",
-          "maxLength": 64
+          "maxGraphemes": 64,
+          "maxLength": 640
         },
         "description": {
           "type": "string",
-          "maxLength": 256
+          "maxGraphemes": 256,
+          "maxLength": 2560
         },
         "avatar": {
           "type": "string"
@@ -82,6 +92,13 @@ A reference to an actor in the network.
         "viewer": {
           "type": "ref",
           "ref": "#viewerState"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "com.atproto.label.defs#label"
+          }
         }
       }
     },
@@ -102,11 +119,13 @@ A reference to an actor in the network.
         },
         "displayName": {
           "type": "string",
-          "maxLength": 64
+          "maxGraphemes": 64,
+          "maxLength": 640
         },
         "description": {
           "type": "string",
-          "maxLength": 256
+          "maxGraphemes": 256,
+          "maxLength": 2560
         },
         "avatar": {
           "type": "string"
@@ -130,6 +149,13 @@ A reference to an actor in the network.
         "viewer": {
           "type": "ref",
           "ref": "#viewerState"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "com.atproto.label.defs#label"
+          }
         }
       }
     },
@@ -303,11 +329,13 @@ A reference to an actor in the network.
         "properties": {
           "displayName": {
             "type": "string",
-            "maxLength": 64
+            "maxGraphemes": 64,
+            "maxLength": 640
           },
           "description": {
             "type": "string",
-            "maxLength": 256
+            "maxGraphemes": 256,
+            "maxLength": 2560
           },
           "avatar": {
             "type": "blob",
@@ -334,7 +362,6 @@ A reference to an actor in the network.
 ---
 
 ## app.bsky.actor.searchActors
-
 
 ```json
 {

--- a/content/lexicons/app-bsky-feed.md
+++ b/content/lexicons/app-bsky-feed.md
@@ -68,6 +68,13 @@ Definitions related to content & activity published in Bluesky.
         "viewer": {
           "type": "ref",
           "ref": "#viewerState"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "com.atproto.label.defs#label"
+          }
         }
       }
     },

--- a/content/lexicons/app-bsky-notification.md
+++ b/content/lexicons/app-bsky-notification.md
@@ -20,6 +20,15 @@ Definitions related to notifications.
   "defs": {
     "main": {
       "type": "query",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "seenAt": {
+            "type": "string",
+            "format": "datetime"
+          }
+        }
+      },
       "output": {
         "encoding": "application/json",
         "schema": {
@@ -60,6 +69,10 @@ Definitions related to notifications.
           },
           "cursor": {
             "type": "string"
+          },
+          "seenAt": {
+            "type": "string",
+            "format": "datetime"
           }
         }
       },

--- a/content/lexicons/app-bsky-notification.md
+++ b/content/lexicons/app-bsky-notification.md
@@ -134,6 +134,13 @@ Definitions related to notifications.
         "indexedAt": {
           "type": "string",
           "format": "datetime"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "com.atproto.label.defs#label"
+          }
         }
       }
     }

--- a/content/lexicons/com-atproto-admin.md
+++ b/content/lexicons/com-atproto-admin.md
@@ -5,6 +5,7 @@ summary: ATP Lexicon - Admin Schemas
 
 <!-- START lex generated content. Please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION! INSTEAD RE-RUN lex TO UPDATE -->
+---
 
 ## com.atproto.admin.defs
 
@@ -41,6 +42,18 @@ summary: ATP Lexicon - Admin Schemas
           ]
         },
         "subjectBlobCids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "createLabelVals": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "negateLabelVals": {
           "type": "array",
           "items": {
             "type": "string"
@@ -101,6 +114,18 @@ summary: ATP Lexicon - Admin Schemas
           "items": {
             "type": "ref",
             "ref": "#blobView"
+          }
+        },
+        "createLabelVals": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "negateLabelVals": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         },
         "reason": {
@@ -307,6 +332,10 @@ summary: ATP Lexicon - Admin Schemas
         "moderation": {
           "type": "ref",
           "ref": "#moderation"
+        },
+        "invitedBy": {
+          "type": "ref",
+          "ref": "com.atproto.server.defs#inviteCode"
         }
       }
     },
@@ -344,6 +373,24 @@ summary: ATP Lexicon - Admin Schemas
         "moderation": {
           "type": "ref",
           "ref": "#moderationDetail"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "com.atproto.label.defs#label"
+          }
+        },
+        "invitedBy": {
+          "type": "ref",
+          "ref": "com.atproto.server.defs#inviteCode"
+        },
+        "invites": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "com.atproto.server.defs#inviteCode"
+          }
         }
       }
     },
@@ -431,6 +478,13 @@ summary: ATP Lexicon - Admin Schemas
           "items": {
             "type": "ref",
             "ref": "#blobView"
+          }
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "com.atproto.label.defs#label"
           }
         },
         "indexedAt": {
@@ -551,6 +605,101 @@ summary: ATP Lexicon - Admin Schemas
         },
         "length": {
           "type": "integer"
+        }
+      }
+    }
+  }
+}
+```
+---
+
+## com.atproto.admin.disableInviteCodes
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.admin.disableInviteCodes",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Disable some set of codes and/or all codes associated with a set of users",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "codes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "accounts": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+---
+
+## com.atproto.admin.getInviteCodes
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.admin.getInviteCodes",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Admin view of invite codes",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "sort": {
+            "type": "string",
+            "knownValues": [
+              "recent",
+              "usage"
+            ],
+            "default": "recent"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "default": 100
+          },
+          "cursor": {
+            "type": "string"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "codes"
+          ],
+          "properties": {
+            "cursor": {
+              "type": "string"
+            },
+            "codes": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "com.atproto.server.defs#inviteCode"
+              }
+            }
+          }
         }
       }
     }
@@ -923,6 +1072,9 @@ summary: ATP Lexicon - Admin Schemas
           "term": {
             "type": "string"
           },
+          "invitedBy": {
+            "type": "string"
+          },
           "limit": {
             "type": "integer",
             "minimum": 1,
@@ -1004,6 +1156,18 @@ summary: ATP Lexicon - Admin Schemas
                 "format": "cid"
               }
             },
+            "createLabelVals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "negateLabelVals": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
             "reason": {
               "type": "string"
             },
@@ -1026,6 +1190,78 @@ summary: ATP Lexicon - Admin Schemas
           "name": "SubjectHasAction"
         }
       ]
+    }
+  }
+}
+```
+---
+
+## com.atproto.admin.updateAccountEmail
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.admin.updateAccountEmail",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Administrative action to update an account's email",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "account",
+            "email"
+          ],
+          "properties": {
+            "account": {
+              "type": "string",
+              "format": "at-identifier",
+              "description": "The handle or DID of the repo."
+            },
+            "email": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+---
+
+## com.atproto.admin.updateAccountHandle
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.admin.updateAccountHandle",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Administrative action to update an account's handle",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "did",
+            "handle"
+          ],
+          "properties": {
+            "did": {
+              "type": "string",
+              "format": "did"
+            },
+            "handle": {
+              "type": "string",
+              "format": "handle"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/content/lexicons/com-atproto-label.md
+++ b/content/lexicons/com-atproto-label.md
@@ -1,0 +1,205 @@
+---
+title: com.atproto.label
+summary: ATP Lexicon - Label Schemas
+---
+
+<!-- START lex generated content. Please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION! INSTEAD RE-RUN lex TO UPDATE -->
+---
+
+## com.atproto.label.defs
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.label.defs",
+  "defs": {
+    "label": {
+      "type": "object",
+      "description": "Metadata tag on an atproto resource (eg, repo or record)",
+      "required": [
+        "src",
+        "uri",
+        "val",
+        "cts"
+      ],
+      "properties": {
+        "src": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the actor who created this label"
+        },
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "AT URI of the record, repository (account), or other resource which this label applies to"
+        },
+        "cid": {
+          "type": "string",
+          "format": "cid",
+          "description": "optionally, CID specifying the specific version of 'uri' resource this label applies to"
+        },
+        "val": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "the short string name of the value or type of this label"
+        },
+        "neg": {
+          "type": "boolean",
+          "description": "if true, this is a negation label, overwriting a previous label"
+        },
+        "cts": {
+          "type": "string",
+          "format": "datetime",
+          "description": "timestamp when this label was created"
+        }
+      }
+    }
+  }
+}
+```
+---
+
+## com.atproto.label.queryLabels
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.label.queryLabels",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Find labels relevant to the provided URI patterns.",
+      "parameters": {
+        "type": "params",
+        "required": [
+          "uriPatterns"
+        ],
+        "properties": {
+          "uriPatterns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of AT URI patterns to match (boolean 'OR'). Each may be a prefix (ending with '*'; will match inclusive of the string leading to '*'), or a full URI"
+          },
+          "sources": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "did"
+            },
+            "description": "Optional list of label sources (DIDs) to filter on"
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 250,
+            "default": 50
+          },
+          "cursor": {
+            "type": "string"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "labels"
+          ],
+          "properties": {
+            "cursor": {
+              "type": "string"
+            },
+            "labels": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "com.atproto.label.defs#label"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+---
+
+## com.atproto.label.subscribeLabels
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.label.subscribeLabels",
+  "defs": {
+    "main": {
+      "type": "subscription",
+      "description": "Subscribe to label updates",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "cursor": {
+            "type": "integer",
+            "description": "The last known event to backfill from."
+          }
+        }
+      },
+      "message": {
+        "schema": {
+          "type": "union",
+          "refs": [
+            "#labels",
+            "#info"
+          ]
+        }
+      },
+      "errors": [
+        {
+          "name": "FutureCursor"
+        }
+      ]
+    },
+    "labels": {
+      "type": "object",
+      "required": [
+        "seq",
+        "labels"
+      ],
+      "properties": {
+        "seq": {
+          "type": "integer"
+        },
+        "labels": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "com.atproto.label.defs#label"
+          }
+        }
+      }
+    },
+    "info": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "knownValues": [
+            "OutdatedCursor"
+          ]
+        },
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}
+```
+<!-- END lex generated TOC please keep comment here to allow auto update -->

--- a/content/lexicons/com-atproto-moderation.md
+++ b/content/lexicons/com-atproto-moderation.md
@@ -5,6 +5,7 @@ summary: ATP Lexicon - Moderation Schemas
 
 <!-- START lex generated content. Please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION! INSTEAD RE-RUN lex TO UPDATE -->
+---
 
 ## com.atproto.moderation.createReport
 
@@ -99,16 +100,36 @@ summary: ATP Lexicon - Moderation Schemas
       "type": "string",
       "knownValues": [
         "com.atproto.moderation.defs#reasonSpam",
+        "com.atproto.moderation.defs#reasonViolation",
+        "com.atproto.moderation.defs#reasonMisleading",
+        "com.atproto.moderation.defs#reasonSexual",
+        "com.atproto.moderation.defs#reasonRude",
         "com.atproto.moderation.defs#reasonOther"
       ]
     },
     "reasonSpam": {
       "type": "token",
-      "description": "Moderation report reason: Spam."
+      "description": "Spam: frequent unwanted promotion, replies, mentions"
+    },
+    "reasonViolation": {
+      "type": "token",
+      "description": "Direct violation of server rules, laws, terms of service"
+    },
+    "reasonMisleading": {
+      "type": "token",
+      "description": "Misleading identity, affiliation, or content"
+    },
+    "reasonSexual": {
+      "type": "token",
+      "description": "Unwanted or mis-labeled sexual content"
+    },
+    "reasonRude": {
+      "type": "token",
+      "description": "Rude, harassing, explicit, or otherwise unwelcoming behavior"
     },
     "reasonOther": {
       "type": "token",
-      "description": "Moderation report reason: Other."
+      "description": "Other: reports not falling under another report category"
     }
   }
 }

--- a/content/lexicons/com-atproto-repo.md
+++ b/content/lexicons/com-atproto-repo.md
@@ -438,13 +438,16 @@ Definitions related to repositories in ATP.
             "default": 50,
             "description": "The number of records to return."
           },
+          "cursor": {
+            "type": "string"
+          },
           "rkeyStart": {
             "type": "string",
-            "description": "The lowest sort-ordered rkey to start from (exclusive)"
+            "description": "DEPRECATED: The lowest sort-ordered rkey to start from (exclusive)"
           },
           "rkeyEnd": {
             "type": "string",
-            "description": "The highest sort-ordered rkey to stop at (exclusive)"
+            "description": "DEPRECATED: The highest sort-ordered rkey to stop at (exclusive)"
           },
           "reverse": {
             "type": "boolean",

--- a/content/lexicons/com-atproto-server.md
+++ b/content/lexicons/com-atproto-server.md
@@ -121,6 +121,10 @@ Definitions related to server behaviors in ATP.
           "properties": {
             "useCount": {
               "type": "integer"
+            },
+            "forAccount": {
+              "type": "string",
+              "format": "did"
             }
           }
         }
@@ -145,30 +149,35 @@ Definitions related to server behaviors in ATP.
 ```
 ---
 
-## com.atproto.server.createSession
+## com.atproto.server.createInviteCodes
 
 ```json
 {
   "lexicon": 1,
-  "id": "com.atproto.server.createSession",
+  "id": "com.atproto.server.createInviteCodes",
   "defs": {
     "main": {
       "type": "procedure",
-      "description": "Create an authentication session.",
+      "description": "Create an invite code.",
       "input": {
         "encoding": "application/json",
         "schema": {
           "type": "object",
           "required": [
-            "password"
+            "codeCount",
+            "useCount"
           ],
           "properties": {
-            "identifier": {
-              "type": "string",
-              "description": "Handle or other identifier supported by the server for the authenticating user."
+            "codeCount": {
+              "type": "integer",
+              "default": 1
             },
-            "password": {
-              "type": "string"
+            "useCount": {
+              "type": "integer"
+            },
+            "forAccount": {
+              "type": "string",
+              "format": "did"
             }
           }
         }
@@ -178,34 +187,87 @@ Definitions related to server behaviors in ATP.
         "schema": {
           "type": "object",
           "required": [
-            "accessJwt",
-            "refreshJwt",
-            "handle",
-            "did"
+            "codes"
           ],
           "properties": {
-            "accessJwt": {
-              "type": "string"
-            },
-            "refreshJwt": {
-              "type": "string"
-            },
-            "handle": {
-              "type": "string",
-              "format": "handle"
-            },
-            "did": {
-              "type": "string",
-              "format": "did"
+            "codes": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }
-      },
-      "errors": [
-        {
-          "name": "AccountTakedown"
+      }
+    }
+  }
+}
+```
+---
+
+## com.atproto.server.defs
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.server.defs",
+  "defs": {
+    "inviteCode": {
+      "type": "object",
+      "required": [
+        "code",
+        "available",
+        "disabled",
+        "forAccount",
+        "createdBy",
+        "createdAt",
+        "uses"
+      ],
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "available": {
+          "type": "integer"
+        },
+        "disabled": {
+          "type": "boolean"
+        },
+        "forAccount": {
+          "type": "string"
+        },
+        "createdBy": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "uses": {
+          "type": "array",
+          "items": {
+            "type": "ref",
+            "ref": "#inviteCodeUse"
+          }
         }
-      ]
+      }
+    },
+    "inviteCodeUse": {
+      "type": "object",
+      "required": [
+        "usedBy",
+        "usedAt"
+      ],
+      "properties": {
+        "usedBy": {
+          "type": "string",
+          "format": "did"
+        },
+        "usedAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
     }
   }
 }
@@ -326,6 +388,58 @@ Definitions related to server behaviors in ATP.
 ```
 ---
 
+## com.atproto.server.getAccountInviteCodes
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.server.getAccountInviteCodes",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Get all invite codes for a given account",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "includeUsed": {
+            "type": "boolean",
+            "default": true
+          },
+          "createAvailable": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "codes"
+          ],
+          "properties": {
+            "codes": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "com.atproto.server.defs#inviteCode"
+              }
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "DuplicateCreate"
+        }
+      ]
+    }
+  }
+}
+```
+---
+
 ## com.atproto.server.getSession
 
 ```json
@@ -352,6 +466,9 @@ Definitions related to server behaviors in ATP.
             "did": {
               "type": "string",
               "format": "did"
+            },
+            "email": {
+              "type": "string"
             }
           }
         }

--- a/content/lexicons/com-atproto-server.md
+++ b/content/lexicons/com-atproto-server.md
@@ -101,6 +101,68 @@ Definitions related to server behaviors in ATP.
 ```
 ---
 
+## com.atproto.server.createAppPassword
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.server.createAppPassword",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Create an app-specific password.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "ref",
+          "ref": "#appPassword"
+        }
+      },
+      "errors": [
+        {
+          "name": "AccountTakedown"
+        }
+      ]
+    },
+    "appPassword": {
+      "type": "object",
+      "required": [
+        "name",
+        "password",
+        "createdAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    }
+  }
+}
+```
+---
+
 ## com.atproto.server.createInviteCode
 
 ```json
@@ -175,9 +237,12 @@ Definitions related to server behaviors in ATP.
             "useCount": {
               "type": "integer"
             },
-            "forAccount": {
-              "type": "string",
-              "format": "did"
+            "forAccounts": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "did"
+              }
             }
           }
         }
@@ -193,9 +258,28 @@ Definitions related to server behaviors in ATP.
             "codes": {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "ref",
+                "ref": "#accountCodes"
               }
             }
+          }
+        }
+      }
+    },
+    "accountCodes": {
+      "type": "object",
+      "required": [
+        "account",
+        "codes"
+      ],
+      "properties": {
+        "account": {
+          "type": "string"
+        },
+        "codes": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
         }
       }
@@ -550,6 +634,61 @@ Definitions related to server behaviors in ATP.
 ```
 ---
 
+## com.atproto.server.listAppPasswords
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.server.listAppPasswords",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List all app-specific passwords.",
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "passwords"
+          ],
+          "properties": {
+            "passwords": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#appPassword"
+              }
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "AccountTakedown"
+        }
+      ]
+    },
+    "appPassword": {
+      "type": "object",
+      "required": [
+        "name",
+        "createdAt"
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    }
+  }
+}
+```
+---
+
 ## com.atproto.server.refreshSession
 
 ```json
@@ -681,6 +820,36 @@ Definitions related to server behaviors in ATP.
           "name": "InvalidToken"
         }
       ]
+    }
+  }
+}
+```
+---
+
+## com.atproto.server.revokeAppPassword
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.server.revokeAppPassword",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Revoke an app-specific password by name.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/content/lexicons/com-atproto-server.md
+++ b/content/lexicons/com-atproto-server.md
@@ -205,6 +205,77 @@ Definitions related to server behaviors in ATP.
 ```
 ---
 
+## com.atproto.server.createSession
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.server.createSession",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Create an authentication session.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "identifier",
+            "password"
+          ],
+          "properties": {
+            "identifier": {
+              "type": "string",
+              "description": "Handle or other identifier supported by the server for the authenticating user."
+            },
+            "password": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "accessJwt",
+            "refreshJwt",
+            "handle",
+            "did"
+          ],
+          "properties": {
+            "accessJwt": {
+              "type": "string"
+            },
+            "refreshJwt": {
+              "type": "string"
+            },
+            "handle": {
+              "type": "string",
+              "format": "handle"
+            },
+            "did": {
+              "type": "string",
+              "format": "did"
+            },
+            "email": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "name": "AccountTakedown"
+        }
+      ]
+    }
+  }
+}
+```
+---
+
 ## com.atproto.server.defs
 
 ```json

--- a/content/lexicons/com-atproto-sync.md
+++ b/content/lexicons/com-atproto-sync.md
@@ -302,7 +302,7 @@ Definitions related to cross-server sync in ATP.
           "latest": {
             "type": "string",
             "format": "cid",
-            "description": "The latest commit you in the commit range (inclusive"
+            "description": "The latest commit in the commit range (inclusive)"
           }
         }
       },

--- a/content/lexicons/com-atproto-sync.md
+++ b/content/lexicons/com-atproto-sync.md
@@ -372,6 +372,74 @@ Definitions related to cross-server sync in ATP.
 ```
 ---
 
+## com.atproto.sync.listRepos
+
+```json
+{
+  "lexicon": 1,
+  "id": "com.atproto.sync.listRepos",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "List dids and root cids of hosted repos",
+      "parameters": {
+        "type": "params",
+        "properties": {
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 1000,
+            "default": 500
+          },
+          "cursor": {
+            "type": "string"
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "repos"
+          ],
+          "properties": {
+            "cursor": {
+              "type": "string"
+            },
+            "repos": {
+              "type": "array",
+              "items": {
+                "type": "ref",
+                "ref": "#repo"
+              }
+            }
+          }
+        }
+      }
+    },
+    "repo": {
+      "type": "object",
+      "required": [
+        "did",
+        "head"
+      ],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        },
+        "head": {
+          "type": "string",
+          "format": "cid"
+        }
+      }
+    }
+  }
+}
+```
+---
+
 ## com.atproto.sync.notifyOfUpdate
 
 ```json


### PR DESCRIPTION
This PR updates the Lexicons to their latest version. They were autogenerated by grabbing a copy of the Lexicons from [the repository](https://github.com/bluesky-social/atproto/tree/main/lexicons) and updating the Markdown with `npx @atproto/lex-cli gen-md`. 👍

I decided not to include the [app.bsky.unspecced](https://github.com/bluesky-social/atproto/tree/main/lexicons/app/bsky/unspecced) Lexicon since I'm not sure if that's going to stick around, will add it if it should be included in the docs.