### PR TITLE
Add heading and description to Lexicons.

### DIFF
--- a/content/lexicons/app-bsky-notification.md
+++ b/content/lexicons/app-bsky-notification.md
@@ -5,7 +5,7 @@ summary: Bluesky Lexicon - Notification Schemas
 
 # app.bsky.notification Lexicon
 
-Definitions related to notifications.
+Definitions related to notifications in Bluesky.
 
 <!-- START lex generated content. Please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION! INSTEAD RE-RUN lex TO UPDATE -->

--- a/content/lexicons/app-bsky-richtext.md
+++ b/content/lexicons/app-bsky-richtext.md
@@ -3,6 +3,10 @@ title: app.bsky.richtext
 summary: Bluesky Lexicon - Richtext Schemas
 ---
 
+# app.bsky.richtext Lexicon
+
+Definitions related to RichText in Bluesky.
+
 <!-- START lex generated content. Please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION! INSTEAD RE-RUN lex TO UPDATE -->
 

--- a/content/lexicons/com-atproto-admin.md
+++ b/content/lexicons/com-atproto-admin.md
@@ -3,6 +3,10 @@ title: com.atproto.admin
 summary: ATP Lexicon - Admin Schemas
 ---
 
+# com.atproto.admin Lexicon
+
+Definitions related to administration in ATP.
+
 <!-- START lex generated content. Please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION! INSTEAD RE-RUN lex TO UPDATE -->
 ---

--- a/content/lexicons/com-atproto-identity.md
+++ b/content/lexicons/com-atproto-identity.md
@@ -3,6 +3,10 @@ title: com.atproto.identity
 summary: ATP Lexicon - Identity Schemas
 ---
 
+# com.atproto.identity Lexicon
+
+Definitions related to identities in ATP.
+
 <!-- START lex generated content. Please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION! INSTEAD RE-RUN lex TO UPDATE -->
 

--- a/content/lexicons/com-atproto-label.md
+++ b/content/lexicons/com-atproto-label.md
@@ -3,6 +3,10 @@ title: com.atproto.label
 summary: ATP Lexicon - Label Schemas
 ---
 
+# com.atproto.label Lexicon
+
+Definitions related to "labels," a general term for metadata in ATP.
+
 <!-- START lex generated content. Please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION! INSTEAD RE-RUN lex TO UPDATE -->
 ---

--- a/content/lexicons/com-atproto-moderation.md
+++ b/content/lexicons/com-atproto-moderation.md
@@ -3,6 +3,10 @@ title: com.atproto.moderation
 summary: ATP Lexicon - Moderation Schemas
 ---
 
+# com.atproto.moderation Lexicon
+
+Definitions related to moderation in ATP.
+
 <!-- START lex generated content. Please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION! INSTEAD RE-RUN lex TO UPDATE -->
 ---


### PR DESCRIPTION
This PR adds a heading and description to Lexicons that are missing them.

Not sure about the wording for some descriptions. From my understanding, ATP Lexicons refer to a single ATP server in the network. So descriptions like "related to moderation in ATP," while it sounds as if it's referring to the whole network it is, in reality, referring to a single server.

Is it appropriate to prefix "related to" with "server," to explicitly indicate it's referencing a single ATP server and is not network-wide? 🤔