### PR TITLE
Added alt attribute to hero image.

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -10,6 +10,7 @@ export default function Hero() {
               src="/img/hero-img.png"
               className="mx-auto w-48 sm:w-64 mb-10"
               title="The AT Protocol"
+              alt=""
             />
             <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl md:text-6xl">
               <span className="block xl:inline text-blue-50">


### PR DESCRIPTION
img elements must have an alt prop, either with meaningful text, or an empty string for decorative images. eslint[jsx-a11y/alt-text](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/tree/HEAD/docs/rules/alt-text.md)