### PR TITLE
update sidebar.js - now scrollable when sidebar content overflows

### DIFF
--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -7,7 +7,7 @@ function classNames(...classes) {
 export default function Sidebar({ navigation, current }) {
   return (
     <div className="hidden relative lg:block bg-white pb-4 w-[208px] rounded-lg">
-      <nav className="sticky top-[10px] px-2" aria-label="Sidebar">
+      <nav className="sticky top-[10px] px-2 overflow-y-scroll h-vh pb-4 max-h-[98vh]" aria-label="Sidebar">
         <h4 className="font-bold text-sm mb-1">Guides</h4>
         <LinksGroup links={navigation.guides} current={current} />
         <h4 className="font-bold text-sm mb-1 mt-4">Specs</h4>


### PR DESCRIPTION
# Changes

_UX finetuning_
* Previously, devices with limited viewport height will clip the content inside `sidebar.js`. Users can now scroll through overflow on sidebar vertical nav. Previously, they had to scroll to the bottom of the main prose content for remaining items to show up

Before - As the number of `<Link />` tags grow within these docs, scrolling to a target `<Link />` through main prose content can get cumbersome. In this example, the target `<Link />` is highlighted in red.

https://user-images.githubusercontent.com/56938909/234152533-1ef62784-543f-4888-82ca-91a653b271ee.mp4




After - sidebar vertical nav is now scrollable on its own. overflow scrolling behavior only appears when viewport clips content, so `position: sticky` behavior still persists

https://user-images.githubusercontent.com/56938909/234152643-ebf56805-6272-42d3-841b-78bfba4ada67.mp4