### PR TITLE
com.atproto.handle.resolve renamed to com.atproto.identity.resolveHandle

### DIFF
--- a/content/guides/identity.md
+++ b/content/guides/identity.md
@@ -53,7 +53,7 @@ The DNS handle is a user-facing identifier — it should be shown in UIs and pro
   <tr>
    <td><strong>Handles</strong>
    </td>
-   <td>Handles are DNS names. They are resolved using the <a href="/lexicons/com-atproto-handle">com.atproto.identity.resolveHandle()</a> XRPC method and should be confirmed by a matching entry in the DID document.
+   <td>Handles are DNS names. They are resolved using the <a href="/lexicons/com-atproto-identity">com.atproto.identity.resolveHandle()</a> XRPC method and should be confirmed by a matching entry in the DID document.
    </td>
   </tr>
   <tr>
@@ -94,7 +94,7 @@ At present, none of the DID methods meet our standards fully. **Therefore we hav
 
 Handles in ATP are domain names which resolve to a DID, which in turn resolves to a DID Document containing the user's signing pubkey and hosting service.
 
-Handle resolution uses the [`com.atproto.identity.resolveHandle`](/lexicons/com-atproto-handle) XRPC method. The method call should be sent to the server identified by the handle, and the handle should be passed as a parameter.
+Handle resolution uses the [`com.atproto.identity.resolveHandle`](/lexicons/com-atproto-identity) XRPC method. The method call should be sent to the server identified by the handle, and the handle should be passed as a parameter.
 
 Here is the algorithm in pseudo-typescript:
 

--- a/content/specs/atp.md
+++ b/content/specs/atp.md
@@ -36,7 +36,7 @@ wip: true
 
 - **Client**: The application running on the user's device. Interacts with the network through a PDS.
 - **Personal Data Server (PDS)**: A server hosting user data. Acts as the user's personal agent on the network.
-- **Name server**. A server mapping domains to DIDs via the `com.atproto.handle.resolve()` API. Often a PDS.
+- **Name server**. A server mapping domains to DIDs via the `com.atproto.identity.resolveHandle()` API. Often a PDS.
 - **Crawling indexer**. A service that is crawling the server to produce aggregated views.
 
 ## Wire protocol (XRPC)
@@ -264,7 +264,7 @@ The com.atproto.* lexicons provides the following behaviors:
 
 - [com.atproto.identity](/lexicons/com-atproto-identity). Handle resolution and changes.
 - [com.atproto.server](/lexicons/com-atproto-server). Account and session management.
-- [com.atproto.handle](/lexicons/com-atproto-moderation). Moderation reporting.
+- [com.atproto.moderation](/lexicons/com-atproto-moderation). Moderation reporting.
 - [com.atproto.repo](/lexicons/com-atproto-repo). Repo CRUD operations.
 - [com.atproto.sync](/lexicons/com-atproto-sync). Repo content sync and streaming.
 


### PR DESCRIPTION
`com.atproto.handle.resolve` was renamed to `com.atproto.identity.resolveHandle` in commit 0f32224d99eda717ceba1ffbc02585e15811bada. Fix remaining references to `com.atproto.handle`.