### PR TITLE
fix: fixed broken hyperlinks related to #46

### DIFF
--- a/content/guides/identity.md
+++ b/content/guides/identity.md
@@ -53,7 +53,7 @@ The DNS handle is a user-facing identifier — it should be shown in UIs and pro
   <tr>
    <td><strong>Handles</strong>
    </td>
-   <td>Handles are DNS names. They are resolved using the <a href="/lexicons/com-atproto-handle">com.atproto.identity.resolveHandle()</a> XRPC method and should be confirmed by a matching entry in the DID document.
+   <td>Handles are DNS names. They are resolved using the <a href="/lexicons/com-atproto-identity#comatprotoidentityresolvehandle">com.atproto.identity.resolveHandle()</a> XRPC method and should be confirmed by a matching entry in the DID document.
    </td>
   </tr>
   <tr>
@@ -94,7 +94,7 @@ At present, none of the DID methods meet our standards fully. **Therefore we hav
 
 Handles in ATP are domain names which resolve to a DID, which in turn resolves to a DID Document containing the user's signing pubkey and hosting service.
 
-Handle resolution uses the [`com.atproto.identity.resolveHandle`](/lexicons/com-atproto-handle) XRPC method. The method call should be sent to the server identified by the handle, and the handle should be passed as a parameter.
+Handle resolution uses the [`com.atproto.identity.resolveHandle`](/lexicons/com-atproto-identity#comatprotoidentityresolvehandle) XRPC method. The method call should be sent to the server identified by the handle, and the handle should be passed as a parameter.
 
 Here is the algorithm in pseudo-typescript:
 


### PR DESCRIPTION
Fixed broken documentation links for com.atproto.identity.resolveHandle().

Broken Link:
/lexicons/com-atproto-handle 

Updated Link:
/lexicons/com-atproto-identity#comatprotoidentityresolvehandle