### PR TITLE
Add a Dockerfile for local rendering w/out npm install.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:20-alpine
+
+EXPOSE 3000/tcp
+COPY . ./
+RUN npm install
+ENTRYPOINT ["npm", "run", "dev"]


### PR DESCRIPTION
I use this for locally checking a render without installing npm on my base host, since I already have docker available. If it's useful for others, may be worth a merge.

Note: I don't have much experience with Dockerfiles in production, and I'm not sure if this is good for that. I just use it for local rendering.