### PR TITLE
fix: improve keyboard and screen reader accessibility

### DIFF
--- a/components/cta.js
+++ b/components/cta.js
@@ -12,7 +12,7 @@ export default function CTA() {
           <br />
         </p>
         <Link href="https://bsky.app">
-          <a className="mt-8 inline-flex w-full items-center justify-center rounded-md border border-transparent bg-white px-5 py-3 text-base font-medium text-blue-600 hover:bg-blue-50 sm:w-auto">
+          <a className="mt-8 inline-flex w-full items-center justify-center rounded-md border border-transparent bg-white px-5 py-3 text-base font-medium text-blue-600 hover:bg-blue-50 focus-visible:outline outline-yellow-500 outline-2 sm:w-auto">
             Join the waitlist
           </a>
         </Link>

--- a/components/footer.js
+++ b/components/footer.js
@@ -32,7 +32,7 @@ const navigation = {
       ),
     },
     {
-      name: 'Bluesky App',
+      name: 'Bluesky Social',
       href: 'https://bsky.app/profile/bsky.app',
       icon: ({ className }) => (
         <FontAwesomeIcon icon={faSquare} className={className} />

--- a/components/footer.js
+++ b/components/footer.js
@@ -32,7 +32,7 @@ const navigation = {
       ),
     },
     {
-      name: 'Bluesky',
+      name: 'Bluesky App',
       href: 'https://bsky.app/profile/bsky.app',
       icon: ({ className }) => (
         <FontAwesomeIcon icon={faSquare} className={className} />
@@ -47,7 +47,7 @@ export default function Footer() {
       <div className="mx-auto max-w-7xl overflow-hidden py-12 px-4 sm:px-6 lg:px-8">
         <nav
           className="-mx-5 -my-2 flex flex-wrap justify-center"
-          aria-label="Footer"
+          aria-label="Bluesky website"
         >
           {navigation.main.map((item) => (
             <div key={item.name} className="px-5 py-2">

--- a/components/header.js
+++ b/components/header.js
@@ -41,7 +41,7 @@ const ExternalLinks = [
     ),
   },
   {
-    name: 'Bluesky App',
+    name: 'Bluesky Social',
     href: 'https://bsky.app/profile/bsky.app',
     icon: ({ className }) => (
       <FontAwesomeIcon icon={faSquare} className={className} />

--- a/components/header.js
+++ b/components/header.js
@@ -41,7 +41,7 @@ const ExternalLinks = [
     ),
   },
   {
-    name: 'Bluesky',
+    name: 'Bluesky App',
     href: 'https://bsky.app/profile/bsky.app',
     icon: ({ className }) => (
       <FontAwesomeIcon icon={faSquare} className={className} />
@@ -68,12 +68,12 @@ function classNames(...classes) {
 export default function Header() {
   return (
     <Popover className="relative z-[20] bg-white">
+      <header>
       <div className="flex items-center justify-between border-b-2 border-gray-100 px-4 sm:px-6 py-4 sm:py-6 md:justify-start md:space-x-10">
         <div className="flex justify-start">
           <Link href="/">
-            <a tabIndex="0">
-              <span className="sr-only">ATP</span>
-              <img className="h-10 w-auto" src="/logo.jpg" alt="" />
+            <a>
+              <img className="h-10 w-auto" src="/logo.jpg" alt="The AT Protocol homepage" />
             </a>
           </Link>
         </div>
@@ -83,20 +83,19 @@ export default function Header() {
             <Bars3Icon className="h-6 w-6" aria-hidden="true" />
           </Popover.Button>
         </div>
-        <nav className="hidden space-x-10 md:flex">
+        <nav aria-label="AT Protocol" className="hidden space-x-10 md:flex">
           {SiteSections.map((item, i) => (
             <Link key={item.href} href={item.href}>
               <a
                 title={item.name}
                 className="text-base font-medium text-gray-500 hover:text-gray-900"
-                tabIndex={i}
               >
                 {item.name}
               </a>
             </Link>
           ))}
         </nav>
-        <div className="hidden items-center justify-end md:flex md:flex-1 lg:w-0">
+        <nav aria-label="External links" className="hidden items-center justify-end md:flex md:flex-1 lg:w-0">
           {ExternalLinks.map((item) => (
             <Link key={item.href} href={item.href}>
               <a title={item.name} className="ml-6">
@@ -104,7 +103,7 @@ export default function Header() {
               </a>
             </Link>
           ))}
-        </div>
+        </nav>
       </div>
 
       <Transition
@@ -170,6 +169,7 @@ export default function Header() {
           </div>
         </Popover.Panel>
       </Transition>
+      </header>
     </Popover>
   )
 }

--- a/components/hero.js
+++ b/components/hero.js
@@ -9,7 +9,7 @@ export default function Hero() {
             <img
               src="/img/hero-img.png"
               className="mx-auto w-48 sm:w-64 mb-10"
-              alt="The @ symbol, with a blue sky and clouds in the background"
+              alt="The AT Protocol logo, an @ symbol with a blue sky and clouds in the background"
             />
             <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl md:text-6xl">
               <span className="block xl:inline text-blue-50">

--- a/components/hero.js
+++ b/components/hero.js
@@ -9,7 +9,7 @@ export default function Hero() {
             <img
               src="/img/hero-img.png"
               className="mx-auto w-48 sm:w-64 mb-10"
-              title="The AT Protocol"
+              alt="The @ symbol, with a blue sky and clouds in the background"
             />
             <h1 className="text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl md:text-6xl">
               <span className="block xl:inline text-blue-50">
@@ -22,14 +22,14 @@ export default function Hero() {
             <div className="mx-auto mt-5 max-w-md sm:flex sm:justify-center md:mt-8">
               <div className="rounded-md shadow">
                 <Link href="https://bsky.app">
-                  <a className="flex w-full items-center justify-center rounded-md border border-transparent bg-blue-600 px-8 py-3 text-base font-medium text-white hover:bg-blue-700 md:py-4 md:px-10 md:text-lg">
+                  <a className="flex w-full items-center justify-center rounded-md border border-transparent bg-blue-600 px-8 py-3 text-base font-medium text-white hover:bg-blue-700 md:py-4 md:px-10 md:text-lg focus-visible:outline outline-yellow-500 outline-2">
                     Join the waitlist
                   </a>
                 </Link>
               </div>
               <div className="mt-3 rounded-md shadow sm:mt-0 sm:ml-3">
                 <Link href="/docs">
-                  <a className="flex w-full items-center justify-center rounded-md border border-transparent bg-white px-8 py-3 text-base font-medium text-blue-600 hover:bg-gray-50 md:py-4 md:px-10 md:text-lg">
+                  <a className="flex w-full items-center justify-center rounded-md border border-transparent bg-white px-8 py-3 text-base font-medium text-blue-600 hover:bg-gray-50 md:py-4 md:px-10 md:text-lg focus-visible:outline outline-yellow-500 outline-2">
                     Docs
                   </a>
                 </Link>

--- a/lib/content.js
+++ b/lib/content.js
@@ -61,7 +61,7 @@ export async function getFile(folder, id) {
     .use(rehypeAutolinkHeadings, {
       behavior: 'append',
       properties: {
-        ariaHidden: true,
+        ariaHidden: "true",
         tabIndex: -1,
         class: 'heading-link',
       },

--- a/pages/community.js
+++ b/pages/community.js
@@ -24,7 +24,7 @@ export default function Community({ navigation }) {
       </div>
 
       <div className="max-w-4xl mx-auto px-4">
-        <div className="relative flex px-6 py-6 border border-gray-300 rounded-xl mb-4 hover:border-blue-500">
+        <div className="relative flex px-6 py-6 border border-gray-300 rounded-xl mb-4 hover:border-blue-500 focus-within:border-blue-500">
           <div className="mr-4 hidden sm:block">
             <span className="bg-blue-500 text-white rounded-lg inline-flex p-2 sm:p-3 ring-4 ring-white">
               <BookOpenIcon
@@ -63,7 +63,7 @@ function Links({ pages }) {
       {pages.map((page, pageIdx) => (
         <div
           key={page.href}
-          className="relative flex items-center px-6 py-6 border border-gray-300 rounded-xl mb-4 hover:border-blue-500"
+          className="relative flex items-center px-6 py-6 border border-gray-300 rounded-xl mb-4 hover:border-blue-500 focus-within:border-blue-500"
         >
           <div className="flex-1">
             <h3 className="text-xl leading-6 font-light">

--- a/pages/community/[id].js
+++ b/pages/community/[id].js
@@ -43,7 +43,7 @@ export default function Guide({ navigation, file }) {
       </div>
       <div className="flex max-w-4xl mx-auto">
         <CommunitySidebar navigation={navigation} current={file.path} />
-        <div className="flex-1 px-4 pb-16">
+        <main className="flex-1 px-4 pb-16">
           {file.tldr ? <TLDR items={file.tldr} /> : ''}
           <div
             className="prose prose-pre:overflow-x-auto prose-pre:max-w-[90vw]"
@@ -57,7 +57,7 @@ export default function Guide({ navigation, file }) {
               />
             </div>
           ) : undefined}
-        </div>
+        </main>
       </div>
       <CTA />
       <Footer />

--- a/pages/docs.js
+++ b/pages/docs.js
@@ -24,8 +24,8 @@ export default function Docs({ navigation }) {
       </div>
 
       <div className="max-w-4xl mx-auto px-4">
-        <h3 className="text-3xl mb-2 font-normal">Guides</h3>
-        <div className="relative flex px-6 py-6 border border-gray-300 rounded-xl mb-4 hover:border-blue-500">
+        <h2 className="text-3xl mb-2 font-normal">Guides</h2>
+        <div className="relative flex px-6 py-6 border border-gray-300 rounded-xl mb-4 hover:border-blue-500 focus-within:border-blue-500">
           <div className="mr-4 hidden sm:block">
             <span className="bg-blue-500 text-white rounded-lg inline-flex p-2 sm:p-3 ring-4 ring-white">
               <AcademicCapIcon
@@ -52,10 +52,10 @@ export default function Docs({ navigation }) {
         </div>
         <Links pages={navigation.guides.slice(1)} />
 
-        <h3 className="text-3xl mb-2 font-normal">Specs</h3>
+        <h2 className="text-3xl mb-2 font-normal">Specs</h2>
         <Links pages={navigation.specs} />
 
-        <h3 className="text-3xl mb-2 font-normal">Lexicons</h3>
+        <h2 className="text-3xl mb-2 font-normal">Lexicons</h2>
         <Links pages={navigation.lexicons} />
       </div>
       <Footer />
@@ -69,7 +69,7 @@ function Links({ pages }) {
       {pages.map((page, pageIdx) => (
         <div
           key={page.href}
-          className="relative flex items-center px-6 py-6 border border-gray-300 rounded-xl mb-4 hover:border-blue-500"
+          className="relative flex items-center px-6 py-6 border border-gray-300 rounded-xl mb-4 hover:border-blue-500 focus-within:border-blue-500"
         >
           <div className="flex-1">
             <h3 className="text-xl leading-6 font-light">

--- a/pages/guides/[id].js
+++ b/pages/guides/[id].js
@@ -42,7 +42,7 @@ export default function Guide({ navigation, file }) {
       </div>
       <div className="flex max-w-4xl mx-auto">
         <Sidebar navigation={navigation} current={file.path} />
-        <div className="flex-1 px-4 pb-16">
+        <main className="flex-1 px-4 pb-16">
           {file.tldr ? <TLDR items={file.tldr} /> : ''}
           <div
             className="prose prose-pre:overflow-x-auto prose-pre:max-w-[90vw]"
@@ -56,7 +56,7 @@ export default function Guide({ navigation, file }) {
               />
             </div>
           ) : undefined}
-        </div>
+        </main>
       </div>
       <CTA />
       <Footer />

--- a/pages/lexicons/[id].js
+++ b/pages/lexicons/[id].js
@@ -41,7 +41,7 @@ export default function Guide({ navigation, file }) {
       </div>
       <div className="flex max-w-4xl mx-auto">
         <Sidebar navigation={navigation} current={file.path} />
-        <div className="flex-1 px-4 pb-16">
+        <main className="flex-1 px-4 pb-16">
           <div
             className="prose prose-pre:overflow-x-auto prose-pre:max-w-[90vw]"
             dangerouslySetInnerHTML={{ __html: file.bodyHTML }}
@@ -54,7 +54,7 @@ export default function Guide({ navigation, file }) {
               />
             </div>
           ) : undefined}
-        </div>
+        </main>
       </div>
       <CTA />
       <Footer />

--- a/pages/specs/[id].js
+++ b/pages/specs/[id].js
@@ -41,7 +41,7 @@ export default function Spec({ navigation, file }) {
       </div>
       <div className="flex max-w-4xl mx-auto">
         <Sidebar navigation={navigation} current={file.path} />
-        <div className="flex-1 px-4 pb-16">
+        <main className="flex-1 px-4 pb-16">
           {file.wip ? (
             <Alert
               title="Work in progress"
@@ -58,7 +58,7 @@ export default function Spec({ navigation, file }) {
               message="This document has not yet been written. Please check back soon for updates."
             />
           ) : undefined}
-        </div>
+        </main>
       </div>
       <CTA />
       <Footer />


### PR DESCRIPTION
Small improvements to page structure (html landmarks) and CSS in order to make the site more usable to folks who are using screen readers or keyboard navigation:
- apply [keyboard focus rings](https://build.washingtonpost.com/resources/accessibility/keyboard-accessibility#Focus%20rings) on clickable elements that didn't have them i.e. "Community" link and guides on docs page
- for improved contrast/visibility, use yellow-gold focus outline color in cases where a link is over a blue background
- reorganize [semantic html headers & page landmarks](https://build.washingtonpost.com/resources/accessibility/semantic-html#Heading%20order%20and%20page%20landmarks) to improve navigation experience for screen reader users
- minor tweaks to alt text and aria-labels to make meanings more clear for screen reader users

Demo video with changes:
https://drive.google.com/file/d/1WxC5IAguH_-72hNDE4xTeuwI6Rxcyvq3/view?usp=share_link