### PR TITLE
Add link to socialweb/atproto-lexicon library

### DIFF
--- a/content/community/projects.md
+++ b/content/community/projects.md
@@ -26,7 +26,7 @@ Read our disclaimer [below](/community/projects#disclaimer).
 - [atproto](https://github.com/MarshalX/atproto) (Python): new, not stable
 - [Chitose](https://github.com/mnogu/chitose) (Python): new, not stable
 - [arroba](https://github.com/snarfed/arroba) (Python): new, not stable. PDS implementation with MST, commit repo, diff and [`com.atproto.sync`](https://github.com/snarfed/bridgy-fed/blob/main/atproto.py) XRPC methods
-
+- [socialweb/atproto-lexicon](https://github.com/socialweb-php/atproto-lexicon) (PHP): Parses and resolves Lexicon schemas; useful for code generation and more.
 
 ## Tutorials and Guides
 


### PR DESCRIPTION
Adding link to socialweb/atproto-lexicon library, a Lexicon schema parser for PHP applications/tools/libraries: https://github.com/socialweb-php/atproto-lexicon

Originally submitted as a PR and merged here: https://github.com/bluesky-social/atproto-ecosystem/pull/48