### PR TITLE
specs/nsid: re-write NSID spec

### DIFF
--- a/content/specs/nsid.md
+++ b/content/specs/nsid.md
@@ -3,30 +3,40 @@ title: Namespaced Identifiers (NSIDs)
 summary: A specification for global semantic IDs.
 ---
 
+# Namespaced Identifiers (NSIDs)
 Namespaced Identifiers (NSIDs) are used to reference Lexicon schemas for records, XRPC endpoints, and more.
 
-The basic structure and semantics of an NSID are a fully-qualified hostname in Reverse Domain-Name Order, followed by a simple name. The hostname part is the "domain authority", and the final segment is the "name".
+The basic structure and semantics of an NSID are a fully-qualified hostname in Reverse Domain-Name Order, followed by a simple name. The hostname part is the **domain authority,** and the final segment is the **name**.
 
 
 ### NSID Syntax
 
 Lexicon string type: `nsid`
 
-A quick summary of NSID syntax is that the domain authority part of an NSID must be a valid handle with the order of segments reversed. That is followed by a name segment which must be an ASCII camel-case string.
+The domain authority part of an NSID must be a valid handle with the order of segments reversed. That is followed by a name segment which must be an ASCII camel-case string.
 
-The full syntax rules:
+For example, `com.example.fooBar` is a syntactically valid NSID, where `com.example` is the domain authority, and `fooBar` is the name segment.
 
-- The overall NSID must contain only ASCII characters. the "domain authority" part and the "name" part are separated by an ASCII period character (`.`)
-- The initial "domain authority" part is made of segments separated by periods (`.`). the domain authority part is at most 253 characters (including periods), and must contain at least two segments
-    - Each segment must have at least 1 and at most 63 characters (not including any periods). the allowed characters are ASCII letters (`a-z`), digits (`0-9`), and hyphens (`-`)
-    - Segments can not start or end with a hyphen.
-    - The first segment (the "top level domain") can not start with a numeric digit
-    - The "domain authority" is not case-sensitive, and should be normalized to lowercase (that is, normalize ASCII `A-Z` to `a-z`)
-- The "name" part must have at least 1 and at most 63 characters
-    - The allowed characters are ASCII letters only (`A-Z`, `a-z`): digits and hyphens are not allowed
-    - The "name" part is case-sensitive and should not be normalized
+The comprehensive list of syntax rules is:
 
-Combining the above rules, the NSID must have at least 3 segments, and can have a maximum total length of 317 characters.
+- Overall NSID:
+    - must contain only ASCII characters
+    - separate the domain authority and the name by an ASCII period character (`.`)
+    - must have at least 3 segments
+    - can have a maximum total length of 317 characters
+- Domain authority:
+    - made of segments separated by periods (`.`)
+    - at most 253 characters (including periods), and must contain at least two segments
+    - each segment must have at least 1 and at most 63 characters (not including any periods)
+    - the allowed characters are ASCII letters (`a-z`), digits (`0-9`), and hyphens (`-`)
+    - segments can not start or end with a hyphen
+    - the first segment (the top-level domain) can not start with a numeric digit
+    - the domain authority is not case-sensitive, and should be normalized to lowercase (that is, normalize ASCII `A-Z` to `a-z`)
+- Name:
+    - must have at least 1 and at most 63 characters
+    - the allowed characters are ASCII letters only (`A-Z`, `a-z`)
+    - digits and hyphens are not allowed
+    - case-sensitive and should not be normalized
 
 A reference regex for NSID is:
 
@@ -37,14 +47,14 @@ A reference regex for NSID is:
 
 ### NSID Syntax Variations
 
-A "fragment" may be appended to an NSID in some contexts to refer to a specific sub-field within the schema. The fragment is separated from the NSID by an ASCII hash character (`#`). The fragment identifier string (after the `#`) has the same syntax restrictions as the final segment of an NSID: ASCII alphabetic, one or more characters, length restricted, etc.
+A **fragment** may be appended to an NSID in some contexts to refer to a specific sub-field within the schema. The fragment is separated from the NSID by an ASCII hash character (`#`). The fragment identifier string (after the `#`) has the same syntax restrictions as the final segment of an NSID: ASCII alphabetic, one or more characters, length restricted, etc.
 
 When referring to a group or pattern of NSIDs, a trailing ASCII star character (`*`) can be used as a "glob" character. For example, `com.atproto.*` would refer to any NSIDs under the `[atproto.com](http://atproto.com)` domain authority, including nested sub-domains (sub-authorities). A free-standing `*` would match all NSIDs from all authorities. Currently, there may be only a single start character; it must be the last character; and it must be at a segment boundary (no partial matching of segment names). This means the start character must be proceeded by a period, or be a bare star matching all NSIDs.
 
 
 ### Examples
 
-Syntaxtually-valid NSIDs:
+Syntactically valid NSIDs:
 
 ```
 com.example.fooBar
@@ -66,7 +76,7 @@ com.example
 
 A **strongly-encouraged** best practice is to use authority domains with only ASCII alphabetic characters (that is, no digits or hyphens). This makes it significantly easier to generate client libraries in most programming languages.
 
-The overall NSID is case-sensitive for display, storage, and validation. However, it is not allowed to have multiple NSIDs which differ only by casing. Namespace authorities are responsible for preventing duplication and confusion. Implementations should not force-lowercase NSIDs.
+The overall NSID is case-sensitive for display, storage, and validation. However, having multiple NSIDs that differ only by casing is not allowed. Namespace authorities are responsible for preventing duplication and confusion. Implementations should not force-lowercase NSIDs.
 
 It is common to use "subdomains" as part of the "domain authority" to organize related NSIDs. For example, the NSID `com.atproto.sync.getHead` uses the `sync` segment. Note that this requires control of the full domain `sync.atproto.com`, in addition to the domain `atproto.com`.
 

--- a/content/specs/nsid.md
+++ b/content/specs/nsid.md
@@ -5,7 +5,7 @@ summary: A specification for global semantic IDs.
 
 Namespaced Identifiers (NSIDs) are used to reference Lexicon schemas for records, XRPC endpoints, and more.
 
-The basic structure and semantics of an NSID are a fully-qualified hostname in Reverse Domain-Name Order, followed by a simple name. The hostname part is the “domain authority”, and the final segment is the “name”.
+The basic structure and semantics of an NSID are a fully-qualified hostname in Reverse Domain-Name Order, followed by a simple name. The hostname part is the "domain authority", and the final segment is the "name".
 
 
 ### NSID Syntax
@@ -16,15 +16,15 @@ A quick summary of NSID syntax is that the domain authority part of an NSID must
 
 The full syntax rules:
 
-- The overall NSID must contain only ASCII characters. the “domain authority” part and the “name” part are separated by an ASCII period character (`.`)
-- The initial “domain authority” part is made of segments separated by periods (`.`). the domain authority part is at most 253 characters (including periods), and must contain at least two segments
+- The overall NSID must contain only ASCII characters. the "domain authority" part and the "name" part are separated by an ASCII period character (`.`)
+- The initial "domain authority" part is made of segments separated by periods (`.`). the domain authority part is at most 253 characters (including periods), and must contain at least two segments
     - Each segment must have at least 1 and at most 63 characters (not including any periods). the allowed characters are ASCII letters (`a-z`), digits (`0-9`), and hyphens (`-`)
     - Segments can not start or end with a hyphen.
-    - The first segment (the “top level domain”) can not start with a numeric digit
-    - The “domain authority” is not case-sensitive, and should be normalized to lowercase (that is, normalize ASCII `A-Z` to `a-z`)
-- The “name” part must have at least 1 and at most 63 characters
+    - The first segment (the "top level domain") can not start with a numeric digit
+    - The "domain authority" is not case-sensitive, and should be normalized to lowercase (that is, normalize ASCII `A-Z` to `a-z`)
+- The "name" part must have at least 1 and at most 63 characters
     - The allowed characters are ASCII letters only (`A-Z`, `a-z`): digits and hyphens are not allowed
-    - The “name” part is case-sensitive and should not be normalized
+    - The "name" part is case-sensitive and should not be normalized
 
 Combining the above rules, the NSID must have at least 3 segments, and can have a maximum total length of 317 characters.
 
@@ -37,9 +37,9 @@ A reference regex for NSID is:
 
 ### NSID Syntax Variations
 
-A “fragment” may be appended to an NSID in some contexts to refer to a specific sub-field within the schema. The fragment is separated from the NSID by an ASCII hash character (`#`). The fragment identifier string (after the `#`) has the same syntax restrictions as the final segment of an NSID: ASCII alphabetic, one or more characters, length restricted, etc.
+A "fragment" may be appended to an NSID in some contexts to refer to a specific sub-field within the schema. The fragment is separated from the NSID by an ASCII hash character (`#`). The fragment identifier string (after the `#`) has the same syntax restrictions as the final segment of an NSID: ASCII alphabetic, one or more characters, length restricted, etc.
 
-When referring to a group or pattern of NSIDs, a trailing ASCII star character (`*`) can be used as a “glob” character. For example, `com.atproto.*` would refer to any NSIDs under the `[atproto.com](http://atproto.com)` domain authority, including nested sub-domains (sub-authorities). A free-standing `*` would match all NSIDs from all authorities. Currently, there may be only a single start character; it must be the last character; and it must be at a segment boundary (no partial matching of segment names). This means the start character must be proceeded by a period, or be a bare star matching all NSIDs.
+When referring to a group or pattern of NSIDs, a trailing ASCII star character (`*`) can be used as a "glob" character. For example, `com.atproto.*` would refer to any NSIDs under the `[atproto.com](http://atproto.com)` domain authority, including nested sub-domains (sub-authorities). A free-standing `*` would match all NSIDs from all authorities. Currently, there may be only a single start character; it must be the last character; and it must be at a segment boundary (no partial matching of segment names). This means the start character must be proceeded by a period, or be a bare star matching all NSIDs.
 
 
 ### Examples
@@ -68,17 +68,17 @@ A **strongly-encouraged** best practice is to use authority domains with only AS
 
 The overall NSID is case-sensitive for display, storage, and validation. However, it is not allowed to have multiple NSIDs which differ only by casing. Namespace authorities are responsible for preventing duplication and confusion. Implementations should not force-lowercase NSIDs.
 
-It is common to use “subdomains” as part of the “domain authority” to organize related NSIDs. For example, the NSID `com.atproto.sync.getHead` uses the `sync` segment. Note that this requires control of the full domain `sync.atproto.com`, in addition to the domain `atproto.com`.
+It is common to use "subdomains" as part of the "domain authority" to organize related NSIDs. For example, the NSID `com.atproto.sync.getHead` uses the `sync` segment. Note that this requires control of the full domain `sync.atproto.com`, in addition to the domain `atproto.com`.
 
-Lexicon language documentation will provide style guidelines on choosing and organizing NSIDs for both record types and XRPC methods. In short, records are usually single nouns, not pluralized. XRPC methods are usually in “verbNoun” form.
+Lexicon language documentation will provide style guidelines on choosing and organizing NSIDs for both record types and XRPC methods. In short, records are usually single nouns, not pluralized. XRPC methods are usually in "verbNoun" form.
 
 
 ### Possible Future Changes
 
 It is conceivable that NSID syntax would be relaxed to allow Unicode characters in the final segment.
 
-The “glob” syntax variation may be modified to extended to make the distinction between single-level and nested matching more explicit.
+The "glob" syntax variation may be modified to extended to make the distinction between single-level and nested matching more explicit.
 
-The “fragment” syntax variation may be relaxed in the future to allow nested references.
+The "fragment" syntax variation may be relaxed in the future to allow nested references.
 
-No automated mechanism for verifying control of a “domain authority” currently exists. Also, not automated mechanism exists for fetching a lexicon schema for a given NSID, or for enumerating all NSIDs for a base domain. 
+No automated mechanism for verifying control of a "domain authority" currently exists. Also, not automated mechanism exists for fetching a lexicon schema for a given NSID, or for enumerating all NSIDs for a base domain. 

--- a/content/specs/nsid.md
+++ b/content/specs/nsid.md
@@ -1,80 +1,84 @@
 ---
-title: NameSpaced IDs (NSIDs)
+title: Namespaced Identifiers (NSIDs)
 summary: A specification for global semantic IDs.
 ---
 
-# NameSpaced IDs (NSIDs)
+Namespaced Identifiers (NSIDs) are used to reference Lexicon schemas for records, XRPC endpoints, and more.
 
-NameSpaced IDs (NSIDs) are used throughout ATP to identify methods, records types, and other semantic information.
+The basic structure and semantics of an NSID are a fully-qualified hostname in Reverse Domain-Name Order, followed by a simple name. The hostname part is the “domain authority”, and the final segment is the “name”.
 
-NSIDs use [Reverse Domain-Name Notation](https://en.wikipedia.org/wiki/Reverse_domain_name_notation) with the additional constraint that the segments prior to the final segment *must* map to a valid domain name. For instance, the owner of `example.com` could use the ID of `com.example.foo` but could not use `com.example.foo.bar` unless they also control `foo.example.com`. These rules are to ensure that schemas are globally unique, have a clear authority mapping (to a registered domain), and can potentially be resolved by request.
 
-Some example NSIDs:
+### NSID Syntax
 
-```text
-com.example.status
-io.social.getFeed
+Lexicon string type: `nsid`
+
+A quick summary of NSID syntax is that the domain authority part of an NSID must be a valid handle with the order of segments reversed. That is followed by a name segment which must be an ASCII camel-case string.
+
+The full syntax rules:
+
+- The overall NSID must contain only ASCII characters. the “domain authority” part and the “name” part are separated by an ASCII period character (`.`)
+- The initial “domain authority” part is made of segments separated by periods (`.`). the domain authority part is at most 253 characters (including periods), and must contain at least two segments
+    - Each segment must have at least 1 and at most 63 characters (not including any periods). the allowed characters are ASCII letters (`a-z`), digits (`0-9`), and hyphens (`-`)
+    - Segments can not start or end with a hyphen.
+    - The first segment (the “top level domain”) can not start with a numeric digit
+    - The “domain authority” is not case-sensitive, and should be normalized to lowercase (that is, normalize ASCII `A-Z` to `a-z`)
+- The “name” part must have at least 1 and at most 63 characters
+    - The allowed characters are ASCII letters only (`A-Z`, `a-z`): digits and hyphens are not allowed
+    - The “name” part is case-sensitive and should not be normalized
+
+Combining the above rules, the NSID must have at least 3 segments, and can have a maximum total length of 317 characters.
+
+A reference regex for NSID is:
+
+```
+/^[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+(\.([a-zA-Z]{1,63}))$
+```
+
+
+### NSID Syntax Variations
+
+A “fragment” may be appended to an NSID in some contexts to refer to a specific sub-field within the schema. The fragment is separated from the NSID by an ASCII hash character (`#`). The fragment identifier string (after the `#`) has the same syntax restrictions as the final segment of an NSID: ASCII alphabetic, one or more characters, length restricted, etc.
+
+When referring to a group or pattern of NSIDs, a trailing ASCII star character (`*`) can be used as a “glob” character. For example, `com.atproto.*` would refer to any NSIDs under the `[atproto.com](http://atproto.com)` domain authority, including nested sub-domains (sub-authorities). A free-standing `*` would match all NSIDs from all authorities. Currently, there may be only a single start character; it must be the last character; and it must be at a segment boundary (no partial matching of segment names). This means the start character must be proceeded by a period, or be a bare star matching all NSIDs.
+
+
+### Examples
+
+Syntaxtually-valid NSIDs:
+
+```
+com.example.fooBar
 net.users.bob.ping
+a-0.b-1.c
+a.b.c
+cn.8.lex.stuff
 ```
 
-## Grammar
+Invalid NSIDs:
 
 ```
-alpha     = "a" / "b" / "c" / "d" / "e" / "f" / "g" / "h" / "i" / "j" / "k" / "l" / "m" / "n" / "o" / "p" / "q" / "r" / "s" / "t" / "u" / "v" / "w" / "x" / "y" / "z" / "A" / "B" / "C" / "D" / "E" / "F" / "G" / "H" / "I" / "J" / "K" / "L" / "M" / "N" / "O" / "P" / "Q" / "R" / "S" / "T" / "U" / "V" / "W" / "X" / "Y" / "Z"
-number    = "1" / "2" / "3" / "4" / "5" / "6" / "7" / "8" / "9" / "0"
-delim     = "."
-segment   = alpha *( alpha / number / "-" )
-authority = segment *( delim segment )
-name      = segment
-nsid      = authority delim name
-nsid-ns   = authority delim "*"
+com.exa💩ple.thing
+com.example
 ```
 
-The `nsid-ns` (a "namespace") can be used in certain situations to designate all names under a namespace, eg `com.example.*`.
 
-## Authority model
+### Usage and Implementation Guidelines
 
-Every NSID asserts a single authority which is identified as the segments prior to the final segment which are then reversed.
+A **strongly-encouraged** best practice is to use authority domains with only ASCII alphabetic characters (that is, no digits or hyphens). This makes it significantly easier to generate client libraries in most programming languages.
 
-```text
-com.example.thing
-^^^^^^^^^^^--------> example.com
-```
+The overall NSID is case-sensitive for display, storage, and validation. However, it is not allowed to have multiple NSIDs which differ only by casing. Namespace authorities are responsible for preventing duplication and confusion. Implementations should not force-lowercase NSIDs.
 
-The authority controls the namespace of all names within it, however there is no hierarchy or relationship between authorities. That is, the domain `example.com` does not hold any authority over `sub.example.com`, and therefore `com.example.*` is considered completely independent of `com.example.sub.*`.
+It is common to use “subdomains” as part of the “domain authority” to organize related NSIDs. For example, the NSID `com.atproto.sync.getHead` uses the `sync` segment. Note that this requires control of the full domain `sync.atproto.com`, in addition to the domain `atproto.com`.
 
-## Parsing
+Lexicon language documentation will provide style guidelines on choosing and organizing NSIDs for both record types and XRPC methods. In short, records are usually single nouns, not pluralized. XRPC methods are usually in “verbNoun” form.
 
-NSIDs are comprised of an "authority" and a "name". Some example resolutions of NSIDs to authorities and names:
 
-|NSID|Authority|Name|
-|-|-|-|
-|`com.example.status`|`example.com`|`status`|
-|`io.social.getFeed`|`social.io`|`getFeed`|
-|`net.users.bob.ping`|`bob.users.net`|`ping`|
+### Possible Future Changes
 
-The domain can be extracted through the following algorithm:
+It is conceivable that NSID syntax would be relaxed to allow Unicode characters in the final segment.
 
-```js
-function getNSIDAuthority (nsid) {
-  // split the nsid into segments
-  const parts = nsid.split('.')
-  // remove the last segment
-  parts.pop()
-  // reverse the order of the segments
-  parts.reverse()
-  // rejoin the segments
-  return parts.join('.')
-}
-```
+The “glob” syntax variation may be modified to extended to make the distinction between single-level and nested matching more explicit.
 
-The name can be extracted through the following algorithm:
+The “fragment” syntax variation may be relaxed in the future to allow nested references.
 
-```js
-function getNSIDName (nsid) {
-  // split the nsid into segments
-  const parts = nsid.split('.')
-  // return the last segment
-  return parts.pop()
-}
-```
+No automated mechanism for verifying control of a “domain authority” currently exists. Also, not automated mechanism exists for fetching a lexicon schema for a given NSID, or for enumerating all NSIDs for a base domain. 


### PR DESCRIPTION
There were some small changes here that were reviewed and merged upstream in atproto (typescript) by @dholms first: https://github.com/bluesky-social/atproto/pull/1085

Notably, not allowing digits in the "method name" part, and being more permissive about the "domain authority" part.