### PR TITLE
fix broken links and typos

### DIFF
--- a/content/community/projects.md
+++ b/content/community/projects.md
@@ -25,7 +25,7 @@ Read our disclaimer [below](/community/projects#disclaimer).
 - [bskyrb](https://github.com/ShreyanJain9/bskyrb) (Ruby): new, not stable
 - [blue-pyinthe-sky](https://github.com/robcerda/blue-pyinthe-sky) (Python): new, not stable
 - [Chitose](https://github.com/mnogu/chitose) (Python): new, not stable
-- [arroba](https://github.com/snarfed/arroba) (Python): new, not stable. PDS implementation with MST, commit repo, diff and [`com.atproto.sync`](https://github.com/snarfed/bridgy-fed/blob/main/atproto.py) XRPC methods
+- [arroba](https://github.com/snarfed/arroba) (Python): new, not stable. PDS implementation with MST, commit repo, diff and `com.atproto.sync` XRPC methods
 - [bsky4j](https://github.com/uakihir0/bsky4j) (Java): new, not stable
 - [socialweb/atproto-lexicon](https://github.com/socialweb-php/atproto-lexicon) (PHP): Parses and resolves Lexicon schemas; useful for code generation
 - [skyfall](https://github.com/mackuba/skyfall) (Ruby): new, not stable; only handles streaming from the firehose

--- a/content/guides/data-repos.md
+++ b/content/guides/data-repos.md
@@ -32,7 +32,7 @@ The content of a repository is laid out in a [Merkle Search Tree (MST)](https://
 
 Every node is an [IPLD](https://ipld.io/) object ([dag-cbor](https://ipld.io/docs/codecs/known/dag-cbor/)) which is referenced by a [CID](https://github.com/multiformats/cid) hash. The arrows in the diagram above represent a CID reference.
 
-This layout is reflected in the [AT URIs](/specs/at-uri-schema):
+This layout is reflected in the [AT URIs](/specs/at-uri-scheme):
 
 <pre><code>Root       | at://alice.com
 Collection | at://alice.com/app.bsky.feed.post
@@ -61,13 +61,13 @@ Multiple types of identifiers are used within a Personal Data Repository.
   <tr>
    <td><strong>NSIDs</strong>
    </td>
-   <td>[Namespaced Identifiers](/specs/nsid) identify the Lexicon type for groups of records within a repository.
+   <td><a href="/specs/nsid">Namespaced Identifiers (NSIDs)</a> identify the Lexicon type for groups of records within a repository.
    </td>
   </tr>
   <tr>
    <td><strong>rkey</strong>
    </td>
-   <td>[Record Keys](/specs/nsid) identify individual records within a collection in a given repository. The format is specified by the collection Lexicon, with some collections having only a single record with a key like "self", and other collections having many records, with keys using a base32-encoded timestamp called a Timestamp Identifier (TID).
+   <td><a href="/specs/record-key">Record Keys</a> ("rkeys") identify individual records within a collection in a given repository. The format is specified by the collection Lexicon, with some collections having only a single record with a key like "self", and other collections having many records, with keys using a base32-encoded timestamp called a Timestamp Identifier (TID).
    </td>
   </tr>
 </table>

--- a/content/specs/lexicon.md
+++ b/content/specs/lexicon.md
@@ -164,7 +164,7 @@ Type-specific fields:
 
 No type-specific fields.
 
-See [Data Model spec](/spec/data-model) for CID restrictions.
+See [Data Model spec](/specs/data-model) for CID restrictions.
 
 ### `array`
 


### PR DESCRIPTION
These are pretty small/simple, may self-merge.

For the bridgy-fed link, not sure why that was linked from an NSID name; the targeted file is a 404. I think snarfed refactored code between projects.