### PR TITLE
Adding open-handles project to the list

### DIFF
--- a/content/community/projects.md
+++ b/content/community/projects.md
@@ -117,6 +117,7 @@ The official Bluesky app is available on the [iOS App](https://apps.apple.com/us
 - [Airspace](https://bsky-airspace.onrender.com/) Social Blade for Bluesky showing history of follows/followers/posts count for any user, by [@nirsd.bsky.social](https://bsky.app/profile/did:plc:gzs37etm32zvsznn775hy35w)
 - [Skythread](http://mackuba.github.io/skythread/), a tool for reading threads in a tree layout, by [@mackuba.eu](https://bsky.app/profile/did:plc:oio4hkxaop4ao4wz2pp3f4cr)
 - [Yup](https://app.yup.io/), an app to cross-post to Bluesky and other social apps
+- [Open Handles](https://github.com/SlickDomique/open-handles), an app to let others create a handle with your domains, by [@domi.zip](https://bsky.app/profile/did:plc:7bwr7mioqql34n2mrqwqypbz)
 
 ## Bots
 


### PR DESCRIPTION
I added a link to repository of a project I made to let people share their domain for custom handles. The working app is at https://handles.domi.zip/