### PR TITLE
Update projects to include ScoreMyWordle bot

### DIFF
--- a/content/community/projects.md
+++ b/content/community/projects.md
@@ -133,6 +133,7 @@ The official Bluesky app is available on the [iOS App](https://apps.apple.com/us
 - [Most Attention-Grabbing Posts](https://bsky.app/profile/did:plc:boopgqnkg2inpleusxo7kj4l), repost posts which receive the most replies, quotes, reposts and likes, by [@lamrongol.bsky.social](https://bsky.app/profile/did:plc:wwqlk2n45es2ywkwrf4dwsr2)
 - [Linux Kernel Releases](https://bsky.app/profile/did:plc:35c6qworuvguvwnpjwfq3b5p) by [@adilson.net.br](https://bsky.app/profile/did:plc:kw6k5btwuh4hazzygvhxygx3)
 - [ai bot](https://bsky.app/profile/did:plc:4hqjfn7m6n5hno3doamuhgef) that reply on command and chat by [@syui.ai](https://bsky.app/profile/did:plc:uqzpqmrjnptsxezjx4xuh2mn)
+- [Score My Wordle](https://bsky.app/profile/did:plc:wems3hfqqjsfenrrd325q6zo) ([GitHub](https://github.com/shaneafsar/wordlescorer/)), provides Wordle stats and scores across Bluesky, Mastodon, and Twitter, by [@shaneafsar.com](https://bsky.app/profile/did:plc:ksl6jmkhz7qli2ywletvvm2z)
 
 ### Disclaimer
 


### PR DESCRIPTION
Added an entry for ScoreMyWordle, which is a bot that now runs across Bluesky, Mastodon, and Twitter.