### PR TITLE
Improve default font-famaily

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,11 @@ module.exports = {
     './components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ["-apple-system", "BlinkMacSystemFont", "\"Segoe UI\"", "Roboto", "\"Helvetica Neue\"", "Arial", "\"Noto Sans\"", "sans-serif", "\"Apple Color Emoji\"", "\"Segoe UI Emoji\"", "\"Segoe UI Symbol\"", "\"Noto Color Emoji\""],
+      }
+    },
   },
   plugins: [require('@tailwindcss/typography'), require('@tailwindcss/forms')],
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
     extend: {
       fontFamily: {
         sans: ["-apple-system", "BlinkMacSystemFont", "\"Segoe UI\"", "Roboto", "\"Helvetica Neue\"", "Arial", "\"Noto Sans\"", "sans-serif", "\"Apple Color Emoji\"", "\"Segoe UI Emoji\"", "\"Segoe UI Symbol\"", "\"Noto Color Emoji\""],
-      }
+      },
     },
   },
   plugins: [require('@tailwindcss/typography'), require('@tailwindcss/forms')],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,7 +7,7 @@ module.exports = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ["-apple-system", "BlinkMacSystemFont", "\"Segoe UI\"", "Roboto", "\"Helvetica Neue\"", "Arial", "\"Noto Sans\"", "sans-serif", "\"Apple Color Emoji\"", "\"Segoe UI Emoji\"", "\"Segoe UI Symbol\"", "\"Noto Color Emoji\""],
+        sans: ['-apple-system', 'BlinkMacSystemFont', '"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', '"Noto Sans"', 'sans-serif', '"Apple Color Emoji"', '"Segoe UI Emoji"', '"Segoe UI Symbol"', '"Noto Color Emoji"'],
       },
     },
   },


### PR DESCRIPTION
The default font-family in tailwind is very Mac-centric and lacks consideration for Windows environments, especially CJK Windows environments.(Note: https://infinnie.github.io/blog/2017/systemui.html)

Currently, tailwind's font-family for sans serif is preceded by system-ui, which results in rendering Malgun Gothic instead of Segoe UI in Korean window environments. Malgun Gothic's readability in English is horrendously bad. This PR fixes that issue.

![screen shot 2023-08-12 102121](https://github.com/bluesky-social/atproto-website/assets/56965274/dec213c6-2f13-4f0b-9a93-dee39a8bdefb)
This is a screenshot of the at-proto site in a Korean Windows environment. You can see that the English is not very readable.

![screen 2023-08-12 102102](https://github.com/bluesky-social/atproto-website/assets/56965274/85786c9c-af6b-4e94-97ad-e07c1d9d7701)
This is a screenshot taken after removing system-ui from the font-family. You can see that the Segoe ui is rendered and is more readable.