### PR TITLE
specs: repo v3

### DIFF
--- a/content/specs/atp.md
+++ b/content/specs/atp.md
@@ -43,7 +43,7 @@ These specifications cover most details as implemented in Bluesky's reference im
 
 **Account Migration:** the identity and repository systems were designed to enable easy migration of accounts between PDS service providers, even in the face of a non-cooperative service provider, without impact on the social graph. Some details have not been worked out yet: optional PDS-to-PDS repository transfer; downstream behavior during transfer grace periods; rate-limit norms to prevent network abuse; blob migration; etc.
 
-**Repository Sync:** the current repository structure and `com.atproto.sync.*` Lexicons include optional `rev` fields. These are used to do partial fetches of repository content "since" a previous revision. This mechanism is largely settled, but not specified here in detail.
+**Repository Sync:** the repository commit schema has a revision field, and the `com.atproto.sync.*` Lexicons can reference these via a `since` parameter to do partial fetches of repository content. This mechanism is largely settled, but not yet specified here in detail.
 
 **Repository Event Stream:** the `com.atproto.sync.subscribeRepos` subscription Lexicon is a core part of the protocol and the details need to be described in more detail. This includes the semantics of the "commit" message type, which includes both a "CAR slice" of new repository blocks, and an operation list.
 

--- a/content/specs/repository.md
+++ b/content/specs/repository.md
@@ -9,7 +9,7 @@ summary: Self-authenticating storage for public account content
 
 Public atproto content (**records**) is stored in per-account repositories (frequently shortened to **repo**). All currently active records are stored in the repository, and current repository contents are publicly available, but both content deletions and account deletions are fully supported.
 
-The repository data structure is content-addressed (a [Merkle-tree](https://en.wikipedia.org/wiki/Merkle_tree)), and every mutation of repository contents (eg, addition, removal, and updates to records) results in a new commit data hash. Commits are cryptographically signed, with rotatable signing keys, which allows recursive validation of content as a whole or in part.
+The repository data structure is content-addressed (a [Merkle-tree](https://en.wikipedia.org/wiki/Merkle_tree)), and every mutation of repository contents (eg, addition, removal, and updates to records) results in a new commit `data` hash value (CID). Commits are cryptographically signed, with rotatable signing keys, which allows recursive validation of content as a whole or in part.
 
 Repositories and their contents are canonically stored in binary [DAG-CBOR](https://ipld.io/docs/codecs/known/dag-cbor/) format, as a graph of [IPLD](https://ipld.io/docs/data-model/) data objects referencing each other by content hash (CID Links). Large binary blobs are not stored directly in repositories, though they are referenced by hash ([CID](https://github.com/multiformats/cid)). This includes images and other media objects. Repositories can be exported as [CAR](https://ipld.io/specs/transport/car/carv1/) files for offline backup, account migration, or other purposes.
 


### PR DESCRIPTION
Small/minimal PR to update repo specs for v3.

Does not get in to all the semantics of the `rev` field (TID clock) in detail, or describe sync mechanisms. We don't have *any* current sync or repo event stream specs, adding those will be a bigger chunk of work. But now (or soon) unblocked!