### PR TITLE
fix app password link

### DIFF
--- a/content/community/projects.md
+++ b/content/community/projects.md
@@ -9,7 +9,7 @@ This is a partial list of community projects. Read instructions for how to submi
 
 ### App Passwords
 
-For the security of your account, when using any third-party clients, please generate an [app password](/specs/atp#app-passwords) at Settings > Advanced > App passwords.
+For the security of your account, when using any third-party clients, please generate an [app password](/specs/xrpc#app-passwords) at Settings > Advanced > App passwords.
 
 App passwords have most of the same abilities as the user's account password, but they're restricted from destructive actions such as account deletion or account migration. They are also restricted from creating additional app passwords.
 


### PR DESCRIPTION
I adjusted the link because the original fragment identifier no longer points to a valid location. It now directs readers to the current App Password documentation.

This has been tested locally.


