### PR TITLE
specs: add tid and record-key string formats

### DIFF
--- a/content/specs/lexicon.md
+++ b/content/specs/lexicon.md
@@ -256,6 +256,8 @@ Strings can optionally be constrained to one of the following `format` types:
 - `did`: generic [DID Identifier](/specs/did)
 - `handle`: [Handle Identifier](/specs/handle)
 - `nsid`: [Namespaced Identifier](/specs/nsid)
+- `tid`: [Timestamp Identifier (TID)](/specs/record-key#record-key-type-tid)
+- `record-key`: [Record Key](/specs/record-key), matching the general syntax ("any")
 - `uri`: generic URI, details specified below
 - `language`: language code, details specified below
 


### PR DESCRIPTION
Will probably wait until support lands in atproto (typescript) before merging this.

closes: https://github.com/bluesky-social/atproto-website/issues/171