### PR TITLE
Add bskyr to community projects

### DIFF
--- a/content/community/projects.md
+++ b/content/community/projects.md
@@ -56,6 +56,7 @@ Read our disclaimer [below](/community/projects#disclaimer).
 #### R
 
 - [atr](https://github.com/JBGruber/atr): auto-generated functions (unstable & unexposed) + user facing functions for selected endpoints (planned to be stable)
+- [bskyr](https://christophertkenny.com/bskyr/): An R interface for posting to and collecting tidy data from Bluesky (stable)
 
 #### Ruby
 


### PR DESCRIPTION
Adds a stable R package (currently on [CRAN](https://cran.r-project.org/web/packages/bskyr/index.html)) to the project listing.