### PR TITLE
Fix hero button text so it doesn't wrap

### DIFF
--- a/components/hero.js
+++ b/components/hero.js
@@ -23,7 +23,7 @@ export default function Hero() {
               <div className="rounded-md shadow">
                 <Link href="/guides/overview">
                   <a className="flex w-full items-center justify-center rounded-md border border-transparent bg-blue-600 px-8 py-3 text-base font-medium text-white hover:bg-blue-700 md:py-4 md:px-10 md:text-lg focus-visible:outline outline-yellow-500 outline-2">
-                    Protocol Overview
+                    Overview
                   </a>
                 </Link>
               </div>


### PR DESCRIPTION
We can't live like this right? :grin: 

![image](https://github.com/bluesky-social/atproto-website/assets/52801504/a1e64c92-59e5-4e66-bcad-2269315a4de8)

->

![image](https://github.com/bluesky-social/atproto-website/assets/52801504/06ccd368-6fda-4fb8-8ac6-63322f8254fc)


(been bugging me for a while)