### PR TITLE
Update blueskyweb.xyz links to equivalent pages on bsky.social

### DIFF
--- a/components/footer.js
+++ b/components/footer.js
@@ -10,7 +10,7 @@ const navigation = {
   social: [
     {
       name: 'Bluesky Website',
-      href: 'https://blueskyweb.xyz',
+      href: 'https://bsky.social',
       icon: BuildingOfficeIcon,
     },
     {

--- a/content/guides/faq.md
+++ b/content/guides/faq.md
@@ -5,7 +5,7 @@ summary: Frequently Asked Questions about ATP
 
 # FAQ
 
-Frequently Asked Questions about the Authenticated Transfer Protocol (ATP). For FAQ about Bluesky, visit [here](https://blueskyweb.xyz/faq).
+Frequently Asked Questions about the Authenticated Transfer Protocol (ATP). For FAQ about Bluesky, visit [here](https://bsky.social/about/faq).
 
 ## Is the AT Protocol a blockchain?
 

--- a/content/guides/overview.md
+++ b/content/guides/overview.md
@@ -25,7 +25,7 @@ The AT Protocol syncs the repositories in a federated networking model. Federati
 
 The three core services in our network are Personal Data Servers (PDS), Relays, and App Views. We're also working on feed generators and labelers.
 
-The lower-level primitives that can get stacked together differently are the repositories, lexicons, and DIDs. We published an overview of our technical decisions around federation architecture [on our blog](https://blueskyweb.xyz/blog/5-5-2023-federation-architecture).
+The lower-level primitives that can get stacked together differently are the repositories, lexicons, and DIDs. We published an overview of our technical decisions around federation architecture [on our blog](https://bsky.social/about/blog/5-5-2023-federation-architecture).
 
 ## Interoperation
 


### PR DESCRIPTION
This PR updates three links that currently point to `blueskyweb.xyz` to instead point to the equivalent pages on `bsky.social`.