### PR TITLE
specs/xrpc: short section on service proxying header

### DIFF
--- a/content/specs/xrpc.md
+++ b/content/specs/xrpc.md
@@ -131,6 +131,8 @@ A few requirements must be met for proxying to happen. These conditions may be e
 - the request must be from an authenticated user with an active account on the PDS
 - rate-limits at the PDS still apply
 
+*Note: during the early roll-out of this protocol feature, endpoints must also be from a Lexicon known to the PDS. This constraint will be relaxed soon, to allow new applications to route requests to their own AppView.*
+
 
 ## Summary of HTTP Headers
 

--- a/content/specs/xrpc.md
+++ b/content/specs/xrpc.md
@@ -110,13 +110,39 @@ const signature = hashAndSign(accountSigningKey, utf8Bytes(headerPayload))
 const jwt = headerPayload + '.' + bytesToBase64Url(signature)
 ```
 
+## Service Proxying
+
+*Note: This is a new protocol feature, and more details are likely to be specified over time.*
+
+The PDS acts as a generic proxy between clients and other atproto services. Clients can use an HTTP header to specify which service in the network they want the request forwarded to (eg, a specific AppView or Labeler service). The PDS will do some safety checks, then forward the request on with an inter-service authentication token (JWT, described above) issued and signed by the user's identity.
+
+The HTTP header is `atproto-proxy`, and the value is a DID (identifying a service), followed by a service endpoint identifier, joined by a `#` character. The PDS resolves the service DID, extracts a service endpoint URL from the DID document, and proxies the request on to the identified server.
+
+An example request header, to proxy to a labeling service, is:
+
+```
+atproto-proxy: did:web:labeler.example.com#atproto_labeler
+```
+
+A few requirements must be met for proxying to happen. These conditions may be extended in the future to address network abuse concerns.
+
+- the target service must have a resolvable DID, a well-formed DID document, and a corresponding service entry with a matching identifier
+- only atproto endpoint paths are supported. This means an `/xrpc/` prefix, followed by a valid NSID and endpoint name. Note that the `/xrpc/` prefix may become configurable in the future
+- the request must be from an authenticated user with an active account on the PDS
+- rate-limits at the PDS still apply
+
+
 ## Summary of HTTP Headers
 
-Clients are expected to use the following headers:
+Clients can use the following request headers:
 
 `Content-Type`: If a request body is present, this header should be included and indicate the content type.
 
 `Authorization`: Contains auth information. See "Authentication" section of this specification for details.
+
+`atproto-proxy`: used for proxying to other atproto services. See "Service Proxying" section of this document for details.
+
+`atproto-accept-labelers`: used by clients to request labels from specific labelers to be included and applied in the response. See [Label](/specs/label) specification for details.
 
 ## Summary of HTTP Status Codes
 


### PR DESCRIPTION
Spec is pretty simple so far. I hedged things a bit with a disclaimer, as I won't be surprised if we end up adding:

- `/.well-known/` pre-flight check
- ability to not forward on service token (or reduce it's scope)
- details about what other headers should be passed along (or not), including content negotiation
- whether to do a "forwarded for" header or not (probably not, for privacy reasons?)
- caching
- websockets
- server-side retries, timeouts, circuit-breaking
- status codes

This references the labels spec, which hasn't merged yet.