### PR TITLE
guides: remove all lexicon links

### DIFF
--- a/content/guides/applications.md
+++ b/content/guides/applications.md
@@ -9,13 +9,13 @@ tldr:
 
 # Applications model
 
-Applications on the AT Protocol connect to the user's Personal Data Server (PDS) to access their account. Once a session is established, the app can use the [lexicons](./lexicon) implemented by the PDS to drive behaviors.
+Applications on the AT Protocol connect to the user's Personal Data Server (PDS) to access their account. Once a session is established, the app can use the lexicons implemented by the PDS to drive behaviors.
 
 In this guide, we'll step through a couple of common patterns (with simple code examples) to help you develop an intuition about this. All APIs shown below are generated using Lexicon's code-generator CLI.
 
 ## Signing in
 
-Sign-in and authentication is a simple session-oriented process. The [com.atproto.server lexicon](/lexicons/com-atproto) includes APIs for creating and managing these sessions.
+Sign-in and authentication is a simple session-oriented process. The `com.atproto.server.*` lexicons include APIs for creating and managing these sessions.
 
 ```typescript
 // create an API instance with my PDS
@@ -75,7 +75,7 @@ If you're noticing the "type" field and wondering how that works, see the [Intro
 
 You'll notice "cids" in some of the schemas. A "cid" is a "Content ID," a sha256 hash of some referenced content. These are used to ensure integrity; for instance, a like includes the cid of the post being liked so that a future edit can be detected and noted in the UI.
 
-### <a href="/lexicons/app-bsky">app.bsky.graph.follow</a>
+### `app.bsky.graph.follow`
 
 A social follow. Example:
 
@@ -87,7 +87,7 @@ A social follow. Example:
 }
 ```
 
-### <a href="/lexicons/app-bsky">app.bsky.feed.like</a>
+### `app.bsky.feed.like`
 
 A like on a piece of content. Example:
 
@@ -102,7 +102,7 @@ A like on a piece of content. Example:
 }
 ```
 
-### <a href="/lexicons/app-bsky">app.bsky.feed.post</a>
+### `app.bsky.feed.post`
 
 A microblog post. Example:
 
@@ -114,7 +114,7 @@ A microblog post. Example:
 }
 ```
 
-### <a href="/lexicons/app-bsky">app.bsky.actor.profile</a>
+### `app.bsky.actor.profile`
 
 A user profile. Example:
 
@@ -126,7 +126,7 @@ A user profile. Example:
 }
 ```
 
-### <a href="/lexicons/app-bsky">app.bsky.feed.repost</a>
+### `app.bsky.feed.repost`
 
 A repost of an existing microblog post (similar to retweets). Example:
 

--- a/content/guides/identity.md
+++ b/content/guides/identity.md
@@ -53,7 +53,7 @@ The DNS handle is a user-facing identifier — it should be shown in UIs and pro
   <tr>
    <td><strong>Handles</strong>
    </td>
-   <td>Handles are DNS names. They are resolved using the <a href="/lexicons/com-atproto">com.atproto.identity.resolveHandle()</a> XRPC method and should be confirmed by a matching entry in the DID document. Details in the <a href="/specs/handle">Handle specification</a>.
+   <td>Handles are DNS names. They are resolved using the `com.atproto.identity.resolveHandle` XRPC method and should be confirmed by a matching entry in the DID document. Details in the <a href="/specs/handle">Handle specification</a>.
    </td>
   </tr>
   <tr>
@@ -94,7 +94,7 @@ At present, none of the DID methods meet our standards fully. **Therefore, we ha
 
 Handles in atproto are domain names which resolve to a DID, which in turn resolves to a DID Document containing the user's signing pubkey and hosting service.
 
-Handle resolution uses the [`com.atproto.identity.resolveHandle`](/lexicons/com-atproto) XRPC method. The method call should be sent to the server identified by the handle, and the handle should be passed as a parameter.
+Handle resolution uses the `com.atproto.identity.resolveHandle` XRPC method. The method call should be sent to the server identified by the handle, and the handle should be passed as a parameter.
 
 Here is the algorithm in pseudo-TypeScript:
 

--- a/content/guides/overview.md
+++ b/content/guides/overview.md
@@ -29,7 +29,7 @@ The lower-level primitives that can get stacked together differently are the rep
 
 ## Interoperation
 
-A global schemas network called [Lexicon](/specs/lexicon) is used to unify the names and behaviors of the calls across the servers. Servers implement "lexicons" to support featuresets, including the core [ATP Lexicon](/lexicons/com-atproto) for syncing user repositories and the [Bsky Lexicon](/lexicons/app-bsky) to provide basic social behaviors.
+A global schemas network called [Lexicon](/specs/lexicon) is used to unify the names and behaviors of the calls across the servers. Servers implement "lexicons" to support featuresets, including the core `com.atproto.*` lexicons for syncing user repositories and the `app.bsky.*` lexicons to provide basic social behaviors.
 
 ![Interop](/img/interop.jpg)
 


### PR DESCRIPTION
Instead of having these go to `docs.bsky.app`, let's just have them not be links at all for now. I suspect we'll want to do a pass over these "guides" and move/remove/refactor before too long.

Resolves: #307 #294 