### PR TITLE
Fix a minor typo in the documentation

### DIFF
--- a/content/specs/lexicon.md
+++ b/content/specs/lexicon.md
@@ -197,7 +197,7 @@ Type-specific fields:
 
 ### `params`
 
-This is a limited-scope type which is only ever used for the `parameters` field on `query`, `procedue`, and `subscription` primary types. These map to HTTP query parameters.
+This is a limited-scope type which is only ever used for the `parameters` field on `query`, `procedure`, and `subscription` primary types. These map to HTTP query parameters.
 
 Type-specific fields:
 


### PR DESCRIPTION
In [the `#params` section](https://atproto.com/specs/lexicon#params) of the Lexicon documentation there was a typo where `procedure` was spelled `procedue`. Since this typo is formatted as code, it's probably best to ensure it's correct.