### PR TITLE
Fix incorrect link in image card

### DIFF
--- a/src/app/[locale]/en.mdx
+++ b/src/app/[locale]/en.mdx
@@ -109,7 +109,7 @@ This guide will introduce you to Lexicon and get you started with building your 
 
 <ImageCard image={WhitepaperPng} href="https://arxiv.org/abs/2402.03239" title="Bluesky and the AT Protocol: Usable Decentralized Social Media" tag="Whitepaper" description="A whitepaper authored by Martin Kleppman and the AT Protocol team." />
 
-<ImageCard image={HowDoesBlueskyWorkBlogpostPng} href="https://arxiv.org/abs/2402.03239" title="How does Bluesky work?" tag="Community Blogpost" description="A blog post by Steve Klabnik describing how Bluesky and ATProto work at a high level." />
+<ImageCard image={HowDoesBlueskyWorkBlogpostPng} href="https://steveklabnik.com/writing/how-does-bluesky-work/" title="How does Bluesky work?" tag="Community Blogpost" description="A blog post by Steve Klabnik describing how Bluesky and ATProto work at a high level." />
 
 </div>
 

--- a/src/app/[locale]/ja.mdx
+++ b/src/app/[locale]/ja.mdx
@@ -109,7 +109,7 @@ What are DIDs and handles? How are domain names involved? How do the identities 
 
 <ImageCard image={WhitepaperPng} href="https://arxiv.org/abs/2402.03239" title="Bluesky と AT プロトコル: 使いやすい分散型ソーシャル メディア" tag="Whitepaper" description="Martin Kleppmann と AT プロトコル チームが執筆したホワイト ペーパー。" />
 
-<ImageCard image={HowDoesBlueskyWorkBlogpostPng} href="https://arxiv.org/abs/2402.03239" title="Bluesky はどのように機能しますか?" tag="Community Blogpost" description="Bluesky と ATProto が高レベルでどのように機能するかを説明する Steve Klabnik のブログ投稿。" />
+<ImageCard image={HowDoesBlueskyWorkBlogpostPng} href="https://steveklabnik.com/writing/how-does-bluesky-work/" title="Bluesky はどのように機能しますか?" tag="Community Blogpost" description="Bluesky と ATProto が高レベルでどのように機能するかを説明する Steve Klabnik のブログ投稿。" />
 
 </div>
 

--- a/src/app/[locale]/pt.mdx
+++ b/src/app/[locale]/pt.mdx
@@ -65,7 +65,7 @@ Este guia apresentará o Lexicon e ajudará você a começar a criar seus própr
 
 <ImageCard image={WhitepaperPng} href="https://arxiv.org/abs/2402.03239" title="Bluesky e o Protocolo AT: Mídias Sociais Descentralizadas Utilizáveis" tag="Whitepaper" description="Um white paper escrito por Martin Kleppmann e pela equipe do AT Protocol." />
 
-<ImageCard image={HowDoesBlueskyWorkBlogpostPng} href="https://arxiv.org/abs/2402.03239" title="Como o Bluesky funciona?" tag="Community Blogpost" description="Uma postagem de blog de Steve Klabnik descrevendo como Bluesky e ATProto funcionam em alto nível." />
+<ImageCard image={HowDoesBlueskyWorkBlogpostPng} href="https://steveklabnik.com/writing/how-does-bluesky-work/" title="Como o Bluesky funciona?" tag="Community Blogpost" description="Uma postagem de blog de Steve Klabnik descrevendo como Bluesky e ATProto funcionam em alto nível." />
 
 </div>
 


### PR DESCRIPTION
Hello,

I have corrected the link in the image card. It was mistakenly pointing to "https://arxiv.org/abs/2402.03239" instead of the intended "https://steveklabnik.com/writing/how-does-bluesky-work/".

Thank you for reviewing this change.

I would also like to thank you for the recent addition of the Japanese translation on atproto.com!