### PR TITLE
specs/mst: 'left' and 'tree' fields are nullable, not optional

### DIFF
--- a/src/app/[locale]/specs/repository/page.mdx
+++ b/src/app/[locale]/specs/repository/page.mdx
@@ -85,12 +85,12 @@ There are many MST nodes in repositories, so it is important that they have a co
 
 The node IPLD schema fields are:
 
-- `l` ("left", CID link, optional): link to sub-tree Node on a lower level and with all keys sorting before keys at this node
+- `l` ("left", CID link, nullable): link to sub-tree Node on a lower level and with all keys sorting before keys at this node
 - `e` ("entries", array of objects, required): ordered list of TreeEntry objects
     - `p` ("prefixlen", integer, required): count of bytes shared with previous TreeEntry in this Node (if any)
     - `k` ("keysuffix", byte array, required): remainder of key for this TreeEntry, after "prefixlen" have been removed
     - `v` ("value", CID Link, required): link to the record data (CBOR) for this entry
-    - `t` ("tree", CID Link, optional): link to a sub-tree Node at a lower level which has keys sorting after this TreeEntry's key (to the "right"), but before the next TreeEntry's key in this Node (if any)
+    - `t` ("tree", CID Link, nullable): link to a sub-tree Node at a lower level which has keys sorting after this TreeEntry's key (to the "right"), but before the next TreeEntry's key in this Node (if any)
 
 When parsing MST data structures, the depth and sort order of keys should be verified. This is particularly true for untrusted inputs, but is simplest to just verify every time. Additional checks on node size and other parameters of the tree structure also need to be limited; see the "Security Considerations" section of this document.
 


### PR DESCRIPTION
This aligns spec with implementation and data in the network.

I think if we did this over from scratch, could make these "optional" instead to save a tiny bit of data. Maybe can change if we do a v4 iteration? But even then might not be worth the churn.

Thanks @str4d for reporting!

Closes: https://github.com/bluesky-social/atproto-website/issues/312