### PR TITLE
specs: clarify data encoding of 'token' type

### DIFF
--- a/src/app/[locale]/specs/lexicon/page.mdx
+++ b/src/app/[locale]/specs/lexicon/page.mdx
@@ -209,7 +209,7 @@ Note that unlike `object`, there is no `nullable` field on `params`.
 
 ### `token`
 
-Tokens are empty data values which exist only to be referenced by name. They are used to define a set of values with specific meanings. The `description` field should clarify the meaning of the token.
+Tokens are empty data values which exist only to be referenced by name. They are used to define a set of values with specific meanings. The `description` field should clarify the meaning of the token. Tokens encode as string data, with the string being the fully-qualified reference to the token itself (NSID followed by an optional fragment).
 
 Tokens are similar to the concept of a "symbol" in some programming languages, distinct from strings, variables, built-in keywords, or other identifiers.
 


### PR DESCRIPTION
Pretty simple, just wasn't explicitly mentioned in the specs.

Closes: https://github.com/bluesky-social/atproto-website/issues/318