### PR TITLE
Fix link to lexicon guide on homepage

### DIFF
--- a/src/app/[locale]/en.mdx
+++ b/src/app/[locale]/en.mdx
@@ -98,7 +98,7 @@ In this article we explore AT Proto from the perspective of distributed backend 
 What are DIDs and handles? How are domain names involved? How do the identities get resolved to user data? This guide will introduce all these concepts and explain how identity works in the Atmosphere.
 </ArticleSummary> */}
 
-<ArticleSummary tag="Guide" title="What is Lexicon, and how do I use it to make a schema?" href="/guides/identity" >
+<ArticleSummary tag="Guide" title="What is Lexicon, and how do I use it to make a schema?" href="/guides/lexicon" >
 This guide will introduce you to Lexicon and get you started with building your own schemas.
 </ArticleSummary>
 

--- a/src/app/[locale]/ja.mdx
+++ b/src/app/[locale]/ja.mdx
@@ -98,7 +98,7 @@ To get started, create a new application in your [developer settings](#), then r
 What are DIDs and handles? How are domain names involved? How do the identities get resolved to user data? This guide will introduce all these concepts and explain how identity works in the Atmosphere.
 </ArticleSummary> */}
 
-<ArticleSummary tag="Guide" title="Lexicon とは何ですか? また、Lexicon を使用してスキーマを作成する方法を教えてください。" href="/guides/identity" >
+<ArticleSummary tag="Guide" title="Lexicon とは何ですか? また、Lexicon を使用してスキーマを作成する方法を教えてください。" href="/guides/lexicon" >
 このガイドでは、Lexicon を紹介し、独自のスキーマの構築方法を説明します。
 </ArticleSummary>
 

--- a/src/app/[locale]/pt.mdx
+++ b/src/app/[locale]/pt.mdx
@@ -54,7 +54,7 @@ Neste guia, criamos um aplicativo multiusuário simples que publica seu "status"
 Neste artigo, exploramos o AT Proto da perspectiva da engenharia de backend distribuída.
 </ArticleSummary>
 
-<ArticleSummary tag="Guide" title="O que é Lexicon e como usá-lo para criar um esquema?" href="/guides/identity" >
+<ArticleSummary tag="Guide" title="O que é Lexicon e como usá-lo para criar um esquema?" href="/guides/lexicon" >
 Este guia apresentará o Lexicon e ajudará você a começar a criar seus próprios esquemas.
 </ArticleSummary>
 


### PR DESCRIPTION
Just fixing a link on the homepage, ensure it points to the lexicon guide rather than the identity guide.