### PR TITLE
Configure MDX editor support

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,10 +1,9 @@
-import { type MDXComponents } from 'mdx/types'
-
 import * as mdxComponents from '@/components/mdx'
 
-export function useMDXComponents(components: MDXComponents) {
-  return {
-    ...components,
-    ...mdxComponents,
-  }
+declare global {
+  type MDXProvidedComponents = typeof mdxComponents
+}
+
+export function useMDXComponents() {
+  return mdxComponents
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,15 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "mdx": {
+    "checkMdx": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.mdx",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
By default a TypeScript program includes all TypeScript files. However, because there’s an `include` pattern, `**/*.mdx`, has to be added for editor support.

The `mdx.checkMdx` option turns subtle error hints in the editor into red squiggly lines.

The global type `MDXProvidedComponents` configures the type of components injected into MDX. This provides support for `<Note />`, `<Image />`, etc.

The `useMDXComponents()` function does not take any arguments. The documentation on which this was based, is wrong.
(https://github.com/vercel/next.js/pull/67188)

For details, see https://github.com/mdx-js/mdx-analyzer