### PR TITLE
Update en.mdx

### DIFF
--- a/src/app/[locale]/guides/glossary/en.mdx
+++ b/src/app/[locale]/guides/glossary/en.mdx
@@ -6,7 +6,7 @@ export const metadata = {
 
 # Glossary of terms
 
-The AT Protocol uses a lot of terms that may not be immediately familiar. This page gives a quick reference to these terms and includes some links to move information. {{className: 'lead'}}
+The AT Protocol uses a lot of terms that may not be immediately familiar. This page gives a quick reference to these terms and includes some links to more information. {{className: 'lead'}}
 
 ## Atmosphere
 


### PR DESCRIPTION
Noticed a typo when reading the Glossary section for the first time. I believe the author meant _more_ not _move_. If that's not correct then please ignore.