### PR TITLE
fix: Add label to language changer

### DIFF
--- a/src/components/LanguageChanger.tsx
+++ b/src/components/LanguageChanger.tsx
@@ -32,6 +32,7 @@ export default function LanguageChanger() {
 
   return (
     <select
+      aria-label="Language"
       onChange={handleChange}
       value={currentLocale}
       className="block w-full appearance-none rounded-md border-0 py-1.5 pl-3 pr-3 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-indigo-600 sm:text-sm sm:leading-6 dark:bg-gray-800 dark:text-gray-100 dark:ring-gray-700"


### PR DESCRIPTION
Add `aria-label="Language"` to the language changer for a11y purposes, so screen readers will announce the label of the control.

I think there's a potential case to be made for a visual label instead, maybe through an icon like this lucide languages one. But, for sighted users it's fairly obvious that it's a language selector, so it probably is not be needed.