### PR TITLE
specs: 'nsid' as a record key format

### DIFF
--- a/src/app/[locale]/specs/record-key/page.mdx
+++ b/src/app/[locale]/specs/record-key/page.mdx
@@ -68,12 +68,15 @@ kjzfcijpj2z2a
 ```
 
 
+### Record Key Type: `nsid`
+
+For cases where the record key must be a valid [NSID](/specs/nsid).
+
 ### Record Key Type: `literal:<value>`
 
 This key type is used when there should be only a single record in the collection, with a fixed, well-known Record Key.
 
 The most common value is `self`, specified as `literal:self` in a Lexicon schema.
-
 
 ### Record Key Type: `any`
 


### PR DESCRIPTION
Probably shouldn't merge until we get support in to typescript codebase.

This will be used by lexicon resolution.