### PR TITLE
Update en.mdx (Fix typo)

### DIFF
--- a/src/app/[locale]/guides/glossary/en.mdx
+++ b/src/app/[locale]/guides/glossary/en.mdx
@@ -56,7 +56,7 @@ Data repositories are signed merkle trees. Their signatures can be verified agai
 
 ## Collection
 
-The "collection" is a bucket of JSON [records](#record) in a [data repository](#data-repo). They support ordered list operations. Every collection is identified by an [NSID](#nsid) which is expected to map to a [Lexicon](#lexicon) schema.
+The "collection" is a bucket of JSON [records](#record) in a [data repository](#data-repo). They support ordered list operations. Every collection is identified by an [NSID](#nsid-namespaced-id) which is expected to map to a [Lexicon](#lexicon) schema.
 
 ## Record
 


### PR DESCRIPTION
**Fix typo**:  
Update link fragment `#nsid` to `#nsid-namespaced-id`
to fix broken link.
