### PR TITLE
fix link to auth

### DIFF
--- a/src/app/[locale]/specs/xrpc/page.mdx
+++ b/src/app/[locale]/specs/xrpc/page.mdx
@@ -45,7 +45,7 @@ A common pattern in Lexicon design is to include a `cursor` parameter for pagina
 
 ## Authentication
 
-The primary client/server authentication and authorization scheme for XRPC is OAuth, described in the [Auth Specification](./auth).
+The primary client/server authentication and authorization scheme for XRPC is OAuth, described in the [Auth Specification](./oauth).
 
 Not all endpoints require authentication, but there is not yet a consistent way to enumerate which endpoints do or do not.
 


### PR DESCRIPTION
Because the link is invalid due to the change by #343, the path is updated from `./auth` to `./oauth`.

This is related to another potential issue. #343 adds a redirect, and it [works](https://atproto.com/specs/auth) well on the English page, but the path does not match in other languages, so it [displays](https://atproto.com/ja/specs/auth) 404. More fundamental corrections may be needed, but in any case, we will solve the impending problems.

