### PR TITLE
Allow direct linking to h3 headers

### DIFF
--- a/src/components/mdx.tsx
+++ b/src/components/mdx.tsx
@@ -35,6 +35,12 @@ export const h2 = function H2(
   return <Heading level={2} {...props} />
 }
 
+export const h3 = function H3(
+  props: Omit<React.ComponentPropsWithoutRef<typeof Heading>, 'level'>,
+) {
+  return <Heading level={3} {...props} />
+}
+
 function InfoIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
   return (
     <svg viewBox="0 0 16 16" aria-hidden="true" {...props}>

--- a/src/mdx/rehype.mjs
+++ b/src/mdx/rehype.mjs
@@ -55,7 +55,10 @@ function rehypeSlugify() {
   return (tree) => {
     let slugify = slugifyWithCounter()
     visit(tree, 'element', (node) => {
-      if (node.tagName === 'h2' && !node.properties.id) {
+      if (
+        (node.tagName === 'h2' || node.tagName === 'h3') &&
+        !node.properties.id
+      ) {
         node.properties.id = slugify(toString(node))
       }
     })


### PR DESCRIPTION
I often find myself wanting to link to `h3` headers in documentation (like the various subtypes of events [in the firehose spec](https://atproto.com/specs/sync#firehose)), then realize this is only supported with `h2` headers .

This PR also adds  ids + anchor links to `h3` headers. 

I considered doing this for `h4`s, but that would mean changing the `Heading` component, and I wanted to keep this review as simple as possible. The only `h4`s that currently exist are in the Korean translation, and they have an `h3` header very close (and probably shouldn't be headers at all). 