### PR TITLE
Update link to "Best Current Practice for OAuth 2.0 Security" to RFC9700

### DIFF
--- a/src/app/[locale]/specs/oauth/en.mdx
+++ b/src/app/[locale]/specs/oauth/en.mdx
@@ -24,7 +24,7 @@ At a high level, we start with the "OAuth 2.1" ([`draft-ietf-oauth-v2-1`](https:
 
 - only the "authorization code" OAuth 2.0 grant type is supported, not "implicit" or other grant types
 - mandatory Proof Key for Code Exchange (PKCE, [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636))
-- security best practices ([`draft-ietf-oauth-security-topics`](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics) and [`draft-ietf-oauth-browser-based-apps`](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps)) are required
+- security best practices ([Best Current Practice for OAuth 2.0 Security](https://datatracker.ietf.org/doc/html/rfc9700) and [`draft-ietf-oauth-browser-based-apps`](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-browser-based-apps)) are required
 
 Unlike a centralized app platform, in atproto there are many independent server implementations, so server discovery and client registration are automated using a combination of public auth server metadata and public client metadata. The `client_id` is a fully-qualified web URL pointing to the public client metadata (JSON document). There is no `client_secret` shared between servers and clients. When initiating a login with a handle or DID, an atproto-specific identity resolution step is required to discover the account’s PDS network location.
 


### PR DESCRIPTION
Draft because I am still checking that we are compliant with the released RFC.