### PR TITLE
Lexicon Enhancement: Support for arrays of strings in `procedure` and `query` encodings

### DIFF
--- a/src/app/[locale]/specs/lexicon/en.mdx
+++ b/src/app/[locale]/specs/lexicon/en.mdx
@@ -80,7 +80,7 @@ Type-specific fields:
 - `parameters` (object, optional): a schema definition with type `params`, describing the HTTP query parameters for this endpoint
 - `output` (object, optional): describes the HTTP response body
     - `description` (string, optional): short description
-    - `encoding` (string, required): MIME type for body contents. Use `application/json` for JSON responses.
+    - `encoding` (string | array of strings, required): MIME type for body contents. Use `application/json` for JSON responses.
     - `schema` (object, optional): schema definition, either an `object`, a `ref`, or a `union` of refs. Used to describe JSON encoded responses, though schema is optional even for JSON responses.
 - `input` (object, optional, only for `procedure`): describes HTTP request body schema, with the same format as the `output` field
 - `errors` (array of objects, optional): set of string error codes which might be returned

--- a/src/app/[locale]/specs/lexicon/ko.mdx
+++ b/src/app/[locale]/specs/lexicon/ko.mdx
@@ -83,7 +83,7 @@ Lexicon 내 특정 정의에 대한 참조는 조각(fragment) 구문(예: `com.
 - `parameters` (객체, 선택): 이 엔드포인트의 HTTP 쿼리 매개변수를 설명하는 `params` 타입의 스키마 정의
 - `output` (객체, 선택): HTTP 응답 본문을 설명합니다.
     - `description` (문자열, 선택): 간단한 설명
-    - `encoding` (문자열, 필수): 본문 내용의 MIME 타입. JSON 응답의 경우 `application/json`을 사용합니다.
+    - `encoding` (문자열 | 문자열 배열, 필수): 본문 내용의 MIME 타입. JSON 응답의 경우 `application/json`을 사용합니다.
     - `schema` (객체, 선택): `object`, `ref` 또는 refs의 `union` 중 하나인 스키마 정의. JSON 인코딩 응답을 설명하는 데 사용되며, JSON 응답의 경우에도 스키마는 선택적입니다.
 - `input` (객체, 선택, `procedure` 전용): HTTP 요청 본문 스키마를 설명하며, `output` 필드와 동일한 형식을 따릅니다.
 - `errors` (객체 배열, 선택): 반환될 수 있는 문자열 오류 코드 집합


### PR DESCRIPTION
TypeScript patch is here: https://github.com/bluesky-social/atproto/pull/3986

Go patch is here: ???

---

Thus far my work on adding native ActivityPub support to the Bluesky PDS hasn't required any specification changes, but this is the first.

In short, ActivityPub has [two official](https://www.w3.org/TR/activitypub/#retrieving-objects) and one unofficially supported `Content-Type` header.

* `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`
* `application/activity+json`
* `application/json`

It's **not possible** to correctly interoperate with other ActivityPub servers _without_ allowing multiple input `Content-Type`'s. The document bodies are identical (all based on JSON LD), which is what I'm proposing here.

Below is an example Lexicon document demonstrating what it would look like.

```json
{
  "lexicon": 1,
  "id": "org.w3.activitypub.putInbox",
  "defs": {
    "main": {
      "type": "procedure",
      "input": {
        "encoding": [
          "application/json",
          "application/activity+json",
          "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\""
        ],
        "schema": { "type": "ref", "ref": "org.w3.activitypub.object" }
      },
      "output": {
        "encoding": "application/activity+json",
        "schema": { "type": "ref", "ref": "org.w3.activitypub.object" }
      }
    }
  }
}
```

Implementations should only ever allow 1 of the listed types.