### PR TITLE
Add missing guides to navigation

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -257,6 +257,8 @@ export const navigation: Array<NavGroup> = [
       { title: 'Data Repositories', href: '/guides/data-repos' },
       { title: 'Schemas & Lexicon', href: '/guides/lexicon' },
       { title: 'PDS Self-Hosting', href: '/guides/self-hosting' },
+      { title: 'Account Migration', href: '/guides/account-migration' },
+      { title: 'Account Lifecyle Events', href: '/guides/account-lifecycle' },
     ],
   },
   {


### PR DESCRIPTION
The guides added in #377 was not included in the sidebar navigation.
This PR updates the sidebar to include the missing entry, ensuring consistent navigation across the site.