### PR TITLE
Suggest clients use resolveIdentity instead of resolveHandle

### DIFF
--- a/src/app/[locale]/specs/handle/en.mdx
+++ b/src/app/[locale]/specs/handle/en.mdx
@@ -101,7 +101,7 @@ blah.arpa
 
 Handles have a limited role in atproto, and need to be resolved to a DID in almost all situations. Resolution mechanisms must demonstrate a reasonable degree of authority over the domain name at a point in time, and need to be relatively efficient to look up. There are currently two supported resolution mechanisms, one using a TXT DNS record containing the DID, and another over HTTPS at a special `/.well-known/` URL.
 
-Clients can rely on network services (eg, their PDS) to resolve handles for them, using the `com.atproto.identity.resolveHandle` endpoint, and don't usually need to implement resolution directly themselves.
+Clients can rely on network services (eg, their PDS) to resolve handles for them, using the `com.atproto.identity.resolveIdentity` endpoint, and don't usually need to implement resolution directly themselves.
 
 The DNS TXT method is the recommended and preferred resolution method for individual handle configuration, but services should fully support both methods. The intended use-case for the HTTPS method is existing large-scale web services which may not have the infrastructure to automate the registration of thousands or millions of DNS TXT records.
 


### PR DESCRIPTION
The [docs for resolveHandle](https://docs.bsky.app/docs/api/com-atproto-identity-resolve-handle) say

> Does not necessarily bi-directionally verify against the the DID document.

whereas [resolveIdentity says](https://docs.bsky.app/docs/api/com-atproto-identity-resolve-identity)

> Resolves an identity (DID or Handle) to a full identity (DID document and verified handle).

Since it's critical to bi-directionally verify DID/Handle resolution, it seems safer to mention `resolveIdentity`, whose response includes the DID without omitting an important caveat.

Alternately maybe this text could mention that a network service offering `resolveHandle` can only be relied on if it's known to do bi-directional verification. (This seems unlikely if that service is an arbitrary user PDS).