### PR TITLE
DID spec: Make length limit more clear

### DIFF
--- a/src/app/[locale]/specs/did/en.mdx
+++ b/src/app/[locale]/specs/did/en.mdx
@@ -33,7 +33,7 @@ The DID Core specification constraints on DID identifier syntax, regardless of t
 - Percent-sign (`%`) is used for "percent encoding" in the identifier section, and must always be followed by two hex characters
 - Query (`?`) and fragment (`#`) sections are allowed in DID URIs, but not in DID identifiers. In the context of atproto, the query and fragment parts are not allowed.
 
-DID identifiers do not generally have a maximum length restriction, but in the context of atproto, there is an initial hard limit of 2 KB.
+DID identifiers do not generally have a maximum length restriction, but in the context of atproto, there is an initial hard limit of 2048 characters.
 
 In the context of atproto, implementations do not need to validate percent encoding. The percent symbol is allowed in DID identifier segments, but the identifier should not end in a percent symbol. A DID containing invalid percent encoding *should* fail any attempt at registration, resolution, etc.
 


### PR DESCRIPTION
2 KB is translated into 2000 bytes in most calculators, but the actual limit accepted by the reference implementation(taken from https://github.com/bluesky-social/atproto/blob/82e3e7bf6bd16ddee6bf684ad10160593b1b0671/packages/did/src/did.ts#L215-L218) is 2048 characters. Therefore, this is more clear as to the exact meaning.

Note: I cannot speak or write Korean, so I did not update that document. If someone else would like to do so, i would be glad to incorporate that change into this PR.