### PR TITLE
Fix typo in guides/applications

### DIFF
--- a/src/app/[locale]/guides/applications/en.mdx
+++ b/src/app/[locale]/guides/applications/en.mdx
@@ -304,7 +304,7 @@ router.post(
 
     try {
       // Write the status record to the user's repository
-      await agent.com.atproto.putRecord({
+      await agent.com.atproto.repo.putRecord({
         repo: agent.assertDid, 
         collection: 'xyz.statusphere.status',
         rkey: TID.nextStr(),

--- a/src/app/[locale]/guides/applications/ja.mdx
+++ b/src/app/[locale]/guides/applications/ja.mdx
@@ -305,7 +305,7 @@ router.post(
 
     try {
       // ステータス レコードをユーザーのリポジトリに書き込みます
-      await agent.com.atproto.putRecord({
+      await agent.com.atproto.repo.putRecord({
       repo: agent.assertDid,
       collection: 'xyz.statusphere.status',
       rkey: TID.nextStr(),

--- a/src/app/[locale]/guides/applications/pt.mdx
+++ b/src/app/[locale]/guides/applications/pt.mdx
@@ -304,7 +304,7 @@ router.post(
 
     try {
       // Write the status record to the user's repository
-      await agent.com.atproto.putRecord({
+      await agent.com.atproto.repo.putRecord({
         repo: agent.assertDid, 
         collection: 'xyz.statusphere.status',
         rkey: TID.nextStr(),


### PR DESCRIPTION
Use the correct API `agent.com.atproto.repo.putRecord` instead of `agent.com.atproto.putRecord`