### PR TITLE
specs: remove mention of NSID fragment syntax

### DIFF
--- a/src/app/[locale]/specs/nsid/en.mdx
+++ b/src/app/[locale]/specs/nsid/en.mdx
@@ -50,7 +50,7 @@ A reference regex for NSID is:
 
 ### NSID Syntax Variations
 
-When referring to a group or pattern of NSIDs, a trailing ASCII star character (`*`) can be used as a "glob" character. For example, `com.atproto.*` would refer to any NSIDs under the `atproto.com` domain authority, including nested sub-domains (sub-authorities). A free-standing `*` would match all NSIDs from all authorities. Currently, there may be only a single start character; it must be the last character; and it must be at a segment boundary (no partial matching of segment names). This means the start character must be proceeded by a period, or be a bare star matching all NSIDs.
+When referring to a group or pattern of NSIDs, a trailing ASCII star character (`*`) can be used as a "glob" character. For example, `com.atproto.*` would refer to any NSIDs under the `atproto.com` domain authority, including nested sub-domains (sub-authorities). A free-standing `*` would match all NSIDs from all authorities. Currently, there may be only a single star character; it must be the last character; and it must be at a segment boundary (no partial matching of segment names). This means the start character must be proceeded by a period, or be a bare star matching all NSIDs.
 
 
 ### Examples


### PR DESCRIPTION
We haven't done anything with that and are not planning to; implementations should not include support for it.

Wildcard stuff is still being debated, won't remove that for now. Did fix a small typo though.