### PR TITLE
I don't think we're actually deprecating XRPC

### DIFF
--- a/src/app/[locale]/guides/glossary/en.mdx
+++ b/src/app/[locale]/guides/glossary/en.mdx
@@ -113,6 +113,6 @@ DAG-CBOR is a serialization format used by [atproto](#at-protocol). It was chose
 
 ## XRPC
 
-XRPC is a term we are deprecating, but it was historically used to describe [atproto's](#at-protocol) flavor of HTTP usage. It stood for "Cross-organizational Remote Procedure Calls" and we regret inventing it, because really we're just using HTTP.
+XRPC is [atproto's](#at-protocol) HTTP API. It stands for "Cross-organizational Remote Procedure Calls" and is a thin wrapper around standard HTTPS. XRPC uses [Lexicon](#lexicon) schemas to define the valid parameters and responses for each API endpoint.
 
 - [HTTP API spec](/specs/xrpc)


### PR DESCRIPTION
I made this branch last week based on initial impressions and am actually opening a PR for it now — I don't think it's currently credible for us to say that we're deprecating XRPC, the term is too popular across the ecosystem and it would actually be less convenient to force everyone to refer to "the AT HTTP APIs" even if there is a desire to emphasize that it's just HTTP, we'd eventually wind up with a new acronym.