### PR TITLE
docs: Rename Lexinomicon to Lexicon Style Guide for improved discoverability

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -38,6 +38,11 @@ const nextConfig = {
         destination: '/specs/oauth',
         permanent: false,
       },
+      {
+        source: '/guides/lexinomicon',
+        destination: '/guides/lexicon-style-guide',
+        permanent: true,
+      },
       // legacy docs
       {
         source: '/faq',

--- a/src/app/[locale]/guides/lexicon-style-guide/en.mdx
+++ b/src/app/[locale]/guides/lexicon-style-guide/en.mdx
@@ -1,10 +1,10 @@
 export const metadata = {
-  title: 'Lexinomicon',
+  title: 'Lexicon Style Guide',
   description:
     'A style guide for creating new ATProto schemas',
 }
 
-# Lexinomicon
+# Lexicon Style Guide
 
 Here are some recommended conventions and best practices for designing Lexicon schemas.
 

--- a/src/app/[locale]/guides/lexicon-style-guide/page.tsx
+++ b/src/app/[locale]/guides/lexicon-style-guide/page.tsx
@@ -1,5 +1,5 @@
 export const metadata = {
-  title: 'Lexinomicon',
+  title: 'Lexicon Style Guide',
   description: 'A style guide for creating new ATProto schemas',
 }
 

--- a/src/app/[locale]/specs/lexicon/en.mdx
+++ b/src/app/[locale]/specs/lexicon/en.mdx
@@ -464,6 +464,6 @@ Implementations which serialize and deserialize data from JSON or CBOR into stru
 
 The validation rules for unexpected additional fields may change. For example, a mechanism for Lexicons to indicate that the schema is "closed" and unexpected fields are not allowed, or a convention around field name prefixes (`x-`) to indicate unofficial extension.
 
-## Lexinomicon
+## Lexicon Style Guide
 
-For an in-depth style guide for designing Lexicons, see the [Lexinomicon](/guides/lexinomicon).
+For an in-depth style guide for designing Lexicons, see the [Lexicon Style Guide](/guides/lexicon-style-guide).

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -261,7 +261,7 @@ export const navigation: Array<NavGroup> = [
       { title: 'Identity', href: '/guides/identity' },
       { title: 'Data Repositories', href: '/guides/data-repos' },
       { title: 'Schemas & Lexicon', href: '/guides/lexicon' },
-      { title: 'Lexinomicon', href: '/guides/lexinomicon' },
+      { title: 'Lexicon Style Guide', href: '/guides/lexicon-style-guide' },
       { title: 'PDS Self-Hosting', href: '/guides/self-hosting' },
       { title: 'Going to production', href: '/guides/going-to-production' },
       { title: 'OAuth Introduction', href: '/guides/oauth' },


### PR DESCRIPTION
## Summary

Renames \"Lexinomicon\" to \"Lexicon Style Guide\" to improve documentation discoverability and accessibility.

- Update page title and navigation entry
- Rename folder from \`lexinomicon\` to \`lexicon-style-guide\`
- Update cross-reference in Lexicon spec
- Add permanent redirect from old URL (no broken links)

## Rationale

### Current Issues

- **Discoverability**: Developers searching for this document may not find it, as "Lexinomicon" doesn't appear in standard search terms and one must know the term first in order to know to search for it.
- **Clarity**: The term requires decoding before understanding its purpose. Direct titles reduce friction when navigating technical documentation.
- **Accessibility**: The gaming / fantasy literature references may not translate across cultures or languages, potentially creating a barrier for international developers.
- **Consistency**: The title's playful tone differs from other documentation sections, making it harder to identify as a style guide or reference document.
- **Information Architecture**: "Style Guide" immediately signals the document type and purpose, helping developers quickly assess if it contains the information they need.
- **Usage**: The term is not widely used ([Google](https://www.google.com/search?q=%22Lexinomicon%22+atproto), [Qwant](https://www.qwant.com/?client=cs-chrome&q=%22Lexinomicon%22+atproto&t=web), [Bluesky](https://bsky.app/search?q=Lexinomicon)) and the community already clarifies it as "Lexicon Style Guide (Lexinomicon)" where clarity matters ([example](https://github.com/bluesky-social/atproto/discussions/4245))

### Benefits of \"Lexicon Style Guide\"

- Immediately communicates document purpose
- Searchable using standard technical documentation terms
- Accessible to all developers regardless of cultural background
- Aligns with industry-standard naming conventions

## Checklist

- [ ] Verify \`/guides/lexicon-style-guide\` renders correctly
- [ ] Verify \`/guides/lexinomicon\` redirects to new URL
- [ ] Verify navigation shows \"Lexicon Style Guide\"
- [ ] Verify cross-reference link in Lexicon spec works