### PR TITLE
specs: remove lexicon 'null' def type

### DIFF
--- a/src/app/[locale]/specs/data-model/en.mdx
+++ b/src/app/[locale]/specs/data-model/en.mdx
@@ -32,7 +32,7 @@ The IPLD Schema language is not used.
 
 | Lexicon Type  | IPLD Type | JSON                 | CBOR                    | Note                    |
 | ---           | ---       | ---                  | ---                     | ---                     |
-| `null`        | null      | Null                 | Special Value (major 7) |                         |
+| -             | null      | Null                 | Special Value (major 7) |                         |
 | `boolean`     | boolean   | Boolean              | Special Value (major 7) |                         |
 | `integer`     | integer   | Number               | Integer (majors 0,1)    | signed, 64-bit          |
 | `string`      | string    | String               | UTF-8 String (major 3)  | Unicode, UTF-8          |

--- a/src/app/[locale]/specs/lexicon/en.mdx
+++ b/src/app/[locale]/specs/lexicon/en.mdx
@@ -16,7 +16,6 @@ This specification describes version 1 of the Lexicon definition language. {{ cl
 
 | Lexicon Type | Data Model Type | Category |
 | --- | --- | --- |
-| `null` | Null | concrete |
 | `boolean` | Boolean | concrete |
 | `integer` | Integer | concrete |
 | `string` | String | concrete |
@@ -105,10 +104,6 @@ As with the primary definitions, every schema object includes these fields:
 
 - `type` (string, required): fixed value for each type
 - `description` (string, optional): short, usually only a sentence or two
-
-### `null`
-
-No additional fields.
 
 ### `boolean`
 


### PR DESCRIPTION
Planning to remove this. Was never implemented in reference implementation (TS), and nobody remembers how it ended up in the spec (!).