### PR TITLE
specs: clarify datetime rules around year zero better

### DIFF
--- a/src/app/[locale]/specs/lexicon/en.mdx
+++ b/src/app/[locale]/specs/lexicon/en.mdx
@@ -335,7 +335,7 @@ A string type which is either a DID (type: did) or a handle (handle). Mostly use
 
 Full-precision date and time, with timezone information.
 
-This format is intended for use with computer-generated timestamps in the modern computing era (eg, after the UNIX epoch). If you need to represent historical or ancient events, ambiguity, or far-future times, a different format is probably more appropriate. Datetimes before the Current Era (year zero) are specifically disallowed.
+This format is intended for use with computer-generated timestamps in the modern computing era (eg, after the UNIX epoch). If you need to represent historical or ancient events, ambiguity, or far-future times, a different format is probably more appropriate. Datetimes before year zero (in astonomical time) are specifically disallowed.
 
 Datetime format standards are notoriously flexible and overlapping. Datetime strings in atproto should meet the [intersecting](https://ijmacd.github.io/rfc3339-iso8601/) requirements of the [RFC 3339](https://www.rfc-editor.org/rfc/rfc3339), [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601), and [WHATWG HTML](https://html.spec.whatwg.org/#dates-and-times) datetime standards.
 
@@ -358,6 +358,7 @@ Valid examples:
 1985-04-12T23:20:50.120Z
 1985-04-12T23:20:50.120000Z
 0001-01-01T00:00:00.000Z
+0000-01-01T00:00:00.000Z
 
 # supported
 1985-04-12T23:20:50.12345678912345Z


### PR DESCRIPTION
Replaces language with "Current Era" (aka, AD) with "astonomical time". Astronomical time has a zero year, CE/AD does not. Almost all computer systems and standards use astronomical time.

Adds clarifying examples.

The main motivation for this was a post which had a "go zero datetime", which is the start of year 1 (`0001-01-01T00:00:00.000Z`). Which raised the question of more exactly when the cut-off is.

Have PRs for interop tests and Go implementation to pair with this.