### PR TITLE
specs: clarify AT-URI syntax w/ non-blessed DIDs

### DIFF
--- a/src/app/[locale]/specs/at-uri-scheme/en.mdx
+++ b/src/app/[locale]/specs/at-uri-scheme/en.mdx
@@ -39,7 +39,7 @@ In current atproto Lexicon use, the **query** and **fragment** parts are not yet
 "at://" AUTHORITY [ "/" COLLECTION [ "/" RKEY ] ]
 ```
 
-The **authority** section is required, must be normalized, and if a DID must be one of the "blessed" DID methods. The optional **collection** part of the path must be a normalized [NSID](./nsid). The optional **rkey** part of the path must be a valid [Record Key](./record-key).
+The **authority** section is required, and should be normalized. Similar to the rules for DID syntax elsewhere in atproto, it is syntaxtually valid to have AT URIs with unsupported DID methods, though the URI will not resolve or function properly. The optional **collection** part of the path must be a normalized [NSID](./nsid). The optional **rkey** part of the path must be a valid [Record Key](./record-key).
 
 An AT URI pointing to a specific record in a repository is not a *strong* reference, in that it is not content-addressed. The record may change or be removed over time, or the DID itself may be deleted or unavailable. For `did:web`, control of the DID (and thus repository) may change over time. For AT URIs with a handle in the authority section, the handle-to-DID mapping can also change.
 


### PR DESCRIPTION
The text here was too strict. For example, a record should pass lexicon validation if it has a string `at-uri` format field with an AT-URI with a non-supported / un-blessed DID method.

This came up over in: https://github.com/bluesky-social/atproto-interop-tests/pull/6