### PR TITLE
Revert "Fix typo: title:langs/detail:langs → title:lang/detail:lang"

### DIFF
--- a/src/app/[locale]/specs/lexicon/en.mdx
+++ b/src/app/[locale]/specs/lexicon/en.mdx
@@ -114,9 +114,9 @@ Specifies a bundle of permissions for use as [OAuth](/specs/oauth) scopes. See [
 Type-specific fields:
 
 - `title` (string, optional): short name for the permission set, which will be displayed to users. Should be limited to a handful of words
-- `title:lang` (map of strings to strings, optional): internationalized/localized variations of `title` for display. The map key strings must be valid language codes; see the `language` lexicon string format
+- `title:langs` (map of strings to strings, optional): internationalized/localized variations of `title` for display. The map key strings must be valid language codes; see the `language` lexicon string format
 - `detail` (string, optional): human-meaningful description of the scope of this permission set, which will be displayed to users. Should be limited to a paragraph or so.
-- `detail:lang` (map of strings to strings, optional): same as `title:lang`, but for `detail`
+- `detail:langs` (map of strings to strings, optional): same as `title:langs`, but for `detail`
 - `permissions` (array of `permission` definitions, required): the permissions included in this set
 
 ## Field Type Definitions

--- a/src/app/[locale]/specs/permission/en.mdx
+++ b/src/app/[locale]/specs/permission/en.mdx
@@ -234,11 +234,11 @@ The below is an example permission set Lexicon. The full syntax is described in 
     "main": {
       "type": "permission-set",
       "title": "Basic App Functionality",
-      "title:lang": {
+      "title:langs": {
         "ja": "基本的なアプリ機能"
       },
       "detail": "Creation of posts and interactions",
-      "detail:lang": {
+      "detail:langs": {
         "ja": "投稿と交流の作成"
       },
       "permissions": [

--- a/src/app/[locale]/specs/permission/ko.mdx
+++ b/src/app/[locale]/specs/permission/ko.mdx
@@ -235,11 +235,11 @@ emoji:☺️
     "main": {
       "type": "permission-set",
       "title": "Basic App Functionality",
-      "title:lang": {
+      "title:langs": {
         "ja": "基本的なアプリ機能"
       },
       "detail": "Creation of posts and interactions",
-      "detail:lang": {
+      "detail:langs": {
         "ja": "投稿と交流の作成"
       },
       "permissions": [


### PR DESCRIPTION
Reverts bluesky-social/atproto-website#491