### PR TITLE
Fix broken link to repository specs

### DIFF
--- a/src/app/[locale]/specs/lexicon/en.mdx
+++ b/src/app/[locale]/specs/lexicon/en.mdx
@@ -70,7 +70,7 @@ All of the primary definition types include these fields:
 
 ### Record
 
-Specifies schema of data objects stored in [Repositories](/spec/repository).
+Specifies schema of data objects stored in [Repositories](/specs/repository).
 
 Type-specific fields:
 


### PR DESCRIPTION
Hi!

There's a link in [this page]( https://atproto.com/specs/lexicon#record) that brings one to https://atproto.com/spec/repository which results in a 404. Should be https://atproto.com/specs/repository instead. 