### PR TITLE
title:langs/detail:langs → title:lang/detail:lang (#491)

### DIFF
--- a/src/app/[locale]/specs/lexicon/en.mdx
+++ b/src/app/[locale]/specs/lexicon/en.mdx
@@ -114,9 +114,9 @@ Specifies a bundle of permissions for use as [OAuth](/specs/oauth) scopes. See [
 Type-specific fields:
 
 - `title` (string, optional): short name for the permission set, which will be displayed to users. Should be limited to a handful of words
-- `title:langs` (map of strings to strings, optional): internationalized/localized variations of `title` for display. The map key strings must be valid language codes; see the `language` lexicon string format
+- `title:lang` (map of strings to strings, optional): internationalized/localized variations of `title` for display. The map key strings must be valid language codes; see the `language` lexicon string format
 - `detail` (string, optional): human-meaningful description of the scope of this permission set, which will be displayed to users. Should be limited to a paragraph or so.
-- `detail:langs` (map of strings to strings, optional): same as `title:langs`, but for `detail`
+- `detail:lang` (map of strings to strings, optional): same as `title:lang`, but for `detail`
 - `permissions` (array of `permission` definitions, required): the permissions included in this set
 
 ## Field Type Definitions

--- a/src/app/[locale]/specs/permission/en.mdx
+++ b/src/app/[locale]/specs/permission/en.mdx
@@ -234,11 +234,11 @@ The below is an example permission set Lexicon. The full syntax is described in 
     "main": {
       "type": "permission-set",
       "title": "Basic App Functionality",
-      "title:langs": {
+      "title:lang": {
         "ja": "基本的なアプリ機能"
       },
       "detail": "Creation of posts and interactions",
-      "detail:langs": {
+      "detail:lang": {
         "ja": "投稿と交流の作成"
       },
       "permissions": [

--- a/src/app/[locale]/specs/permission/ko.mdx
+++ b/src/app/[locale]/specs/permission/ko.mdx
@@ -235,11 +235,11 @@ emoji:☺️
     "main": {
       "type": "permission-set",
       "title": "Basic App Functionality",
-      "title:langs": {
+      "title:lang": {
         "ja": "基本的なアプリ機能"
       },
       "detail": "Creation of posts and interactions",
-      "detail:langs": {
+      "detail:lang": {
         "ja": "投稿と交流の作成"
       },
       "permissions": [


### PR DESCRIPTION
This is re-opening https://github.com/bluesky-social/atproto-website/pull/491 from @mkizka. The previous PR was reverted while we checked the history of the field name, and check what was being used in the network today.

I found several published permission-sets which use `title:lang` and/or `detail:lang`. There are a few permission-sets which define `title:langs` or `detail:langs`, but only as empty objects with no values.

I dug around and couldn't find a specific decision or discussion about changing to the plural version. It's possible that I simply made a mistake when going from the earlier proposals to the final specs.

Given all this, I think we are leaning towards updating the specs, and the indigo implementation, to singular (`title:lang` / `detail:lang`).

Thanks again to @mkizka for catching this before there was too much divergence in the ecosystem!