### PR TITLE
specs: remove OAuth disclaimer

### DIFF
--- a/src/app/[locale]/specs/oauth/en.mdx
+++ b/src/app/[locale]/specs/oauth/en.mdx
@@ -7,10 +7,6 @@ export const metadata = {
 # OAuth
 
 <Note>
-The OAuth profile for atproto is new and may be revised based on feedback from the development community and ongoing standards work. Read more about the rollout in the [OAuth Roadmap](https://github.com/bluesky-social/atproto/discussions/2656).
-</Note>
-
-<Note>
 This specification is authoritative, but is not an implementation guide and does not provide much background or context around design decisions. The earlier [design proposal](https://github.com/bluesky-social/proposals/tree/main/0004-oauth) is not authoritative but provides more context and examples. SDK documentation and the [client implementation guide](https://docs.bsky.app/docs/advanced-guides/oauth-client) are more approachable for developers.
 </Note>
 


### PR DESCRIPTION
OAuth is likely to continue to evolve, but it is a stable part of the protocol, and this disclaimer is no longer helpful.