### PR TITLE
clarify domain handle limitation in glossary

### DIFF
--- a/src/app/[locale]/guides/glossary/en.mdx
+++ b/src/app/[locale]/guides/glossary/en.mdx
@@ -47,7 +47,7 @@ Lexicon's sole purpose is to help developers build compatible software.
 
 ## Data Repo
 
-The "data repository" or "repo" is the public dataset which represents a user. It is comprised of [collections](#collection) of JSON [records](#record) and unstructured [blobs](#blob). Every repo is assigned a single permanent [DID](#did-decentralized-id) which identifies it. Repos may also have any number of [domain handles](#handle) which act as human-readable names.
+The "data repository" or "repo" is the public dataset which represents a user. It is comprised of [collections](#collection) of JSON [records](#record) and unstructured [blobs](#blob). Every repo is assigned a single permanent [DID](#did-decentralized-id) which identifies it. Repos may also have a single [domain handle](#handle) which act as human-readable names.
 
 Data repositories are signed merkle trees. Their signatures can be verified against the key material published under the repo's [did](#did-decentralized-id).
 


### PR DESCRIPTION
In the repository section of the glossary, it is described as if a repository can have any number of handles. This is not accurate, so I will correct it.

In the [current specification](https://atproto.com/specs/did#did-documents), one repository is not allowed to have multiple handles. You can create a link to one DID from multiple handles, but you should not allow it because it will fail to [verify](https://atproto.com/specs/handle#handle-resolution) it.