### PR TITLE
specs: update repo, sync, and account specs for Sync 1.1

### DIFF
--- a/src/app/[locale]/specs/account/en.mdx
+++ b/src/app/[locale]/specs/account/en.mdx
@@ -73,7 +73,7 @@ However, in the common case, when there is an active account on a functional cur
 
 - creating an account on the new PDS (which may start with `active` false, such as `deactivated`)
 - migrating data from the old PDS to the new PDS
-- updating identity (DID document) to point to the new PDS and using a new atproto signing key. For PLC DIDs, usually involves updating PLC rotation keys as well. This results in an `#identity` event being emitted from at least one of the PDS hosts.
+- updating identity (DID document) to point to the new PDS and using a new atproto signing key. For PLC DIDs, usually involves updating PLC rotation keys as well. This results in an `#identity` event being emitted from at least the new PDS host, and ideally from the old PDS as well.
 - updating account status on both PDS instances, such that old is inactive, and new is active. This results in `#account` event being emitted from each PDS.
 - emitting a `#sync` and/or `#commit` event from the new PDS, signed by the new atproto signing key, with a higher commit `rev`.
 

--- a/src/app/[locale]/specs/repository/en.mdx
+++ b/src/app/[locale]/specs/repository/en.mdx
@@ -1,12 +1,12 @@
 export const header = {
   title: 'Repository',
   description:
-    'Self-authenticating storage for public account content',
+    'Self-certifying storage for public account content',
 }
 
 # Repository
 
-Each atproto account has a **repository** (or "repo") which stores all of their public data **records**. Repository contents are entirely public and verifiable. Record deletion is supported without leaving a trace or "tombstone" of previous contents. {{ className: 'lead' }}
+Each atproto account has a **repository** (or "repo") which stores all of their public data **records**. Repository contents are entirely public and verifiable ("self-certifying"). Record deletion is supported without leaving a trace or "tombstone" of previous contents. {{ className: 'lead' }}
 
 The repository data structure is a content-addressed [Merkle-tree](https://en.wikipedia.org/wiki/Merkle_tree). Creating, updating, or deleting records (or any other mutations to the repository) changes the root hash value of the overall repository tree. Each published version of the repository tree structure is represented as a **commit**. Commits are cryptographically signed, with rotatable signing keys, which allows recursive authentication of either the repository structure as a whole, or compact "proof chains" for individual records. {{ className: 'lead' }}
 
@@ -149,7 +149,7 @@ Some details about representing repository diffs are "CAR slices":
 - parsing implementation must be tolerant of additional unexpected blocks in the diff, which they should ignore
   - note that unreasonable quantities of unnecessary block data may be considered a form of resource abuse
 
-The diff is a partial Merkle tree, including a signed commit, and can be partially verified. For example, the diff contains a "proof chain" to verify any created or updated records. However, without knowing more about the previous state of the repository, it is not possible to enumerate or confirm which record paths have been deleted.
+The diff is a partial Merkle tree, including a signed commit, and can be partially verified in isolation. For example, the diff contains a "proof chain" to verify any created or updated records. If both metadata about the previous state of the repository and a complete set of record operations are available, then it becomes possible to fully verify the integrity of the diff.
 
 The sync "firehose" mechanism uses a process called "operation inversion" to validate a list of record operations against a diff. In this process, the diff is parsed as a partial MST, and then each operation is applied in reverse: a "create" is applied as a "delete", etc. After all operations have been applied, the root CID (hash) of the MST is recomputed, and should match the `data` field of the previous revision of the repository. If the list of record operations is inaccurate or incomplete, the inverted MST will not match.
 

--- a/src/app/[locale]/specs/sync/en.mdx
+++ b/src/app/[locale]/specs/sync/en.mdx
@@ -17,7 +17,7 @@ As described in the [Repository specification](/specs/repo), each commit to a re
 
 Synchronizing services should reject or ignore repository updates with revision values corresponding to future timestamps (beyond a short fuzzy time drift window). Services can track the commit revision for every account they have seen, and use this to verify synchronization status.
 
-Clients making API requests to a service may want to know if that service has synchronized and indexed recent updates to the most relevant account repository. For example, if a client updates a profile record for an account (by writing to the PDS), and then immediately requests an updated view of the account profile from a separate service, the client would want to know if the record update was applied. Services can indicate synchronization status using the `Atproto-Repo-Rev` HTTP response header, which should contain a single commit revision (TID) of the relevant account. This mechanism is only relevant to API endpoints where a single account was specified.
+Clients making API requests to a service may want to know if that service has synchronized and indexed recent updates to the authenticated account's repository. For example, if a client updates a profile record for their account (by writing to the PDS), and then immediately requests an updated view of their profile from a separate service, the client would want to know if the record update was applied. Services can indicate synchronization status using the `Atproto-Repo-Rev` HTTP response header, which should contain a single commit revision (TID) of the account making the API request.
 
 
 ## Repository Exports
@@ -171,7 +171,7 @@ Here is a summary of validation rules and behaviors:
 - services should verify `#commit` message `blocks` field (CAR diff) against the `ops` list and `prevData` field, using record operation MST inversion
 - services should reject any event messages which exceed reasonable size limits.
 - services should verify that repository data structures are valid against the specification. Missing fields, incorrect MST structure, or other protocol-layer violations should result in events being rejected.
-- services may apply rate-limits to identity, account, commit, and sync events, and suspend accounts or upstream services which violate those limits. Rate limits might also be applied to recovery modes such as invalid signatures resulting in an identity refresh, missing or out-of-order commits, etc.
+- services may apply rate-limits to identity, account, commit, and sync events, and throttle accounts or upstream services which violate those limits. Rate limits might also be applied to recovery modes such as invalid signatures resulting in an identity refresh, missing or out-of-order commits, etc.
 - services should ignore `#commit` and `#sync` events with a `rev` lower or equal to the most recent successfully processed `rev` for that DID, and should reject commit events with a `rev` corresponding to a future timestamp (beyond a clock drift window of a few minutes)
 - services should check the `since` value in `#commit` events, and if it is not consistent with the most recent `rev` for that DID, mark the repo as out-of-sync
 - similarly, services should check `#commit` message `prevData` values against the most recent commit object `data` field


### PR DESCRIPTION
This finally folds in most of the changes from the Sync 1.1 proposal (https://github.com/bluesky-social/proposals/tree/main/0006-sync-iteration). I also did some general copy-edits and updates to the repo and sync specs.

I compared against daniel's IETF draft (https://www.ietf.org/archive/id/draft-holmgren-at-repository-00.html) when restructuring things, though the level of detail is different enough that copy/paste didn't make sense. I'm open to doing another pass copying over cleaner language and examples from that document in the future though.

These changes should not conflict with (and don't need to block) larger website changes.

This PR does not include:
- updates to semi-spec "guides", like those for account migration and account lifecycle (will hit those separately)
- updates to non-specification docs or tutorials (a lot in flight there)
- much sync motivation or philosophy stuff. eg, don't get in to the concept of "terminating sync"
- a detailed description of what MST nodes inversion requires. I don't think we have a solid technical description of that; the language here matches the original sync proposal and our IETF draft