### PR TITLE
fix: wire up ExplainerUnit 'LEARN MORE' as a link

### DIFF
--- a/src/components/home/ExplainerUnit.tsx
+++ b/src/components/home/ExplainerUnit.tsx
@@ -157,7 +157,7 @@ export function ExplainerUnit() {
               isAutoRotating={!hasInteracted}
             />
           ))}
-          <ExplainerUnitCTA>LEARN MORE</ExplainerUnitCTA>
+          <ExplainerUnitCTA href="/guides/understanding-atproto">LEARN MORE</ExplainerUnitCTA>
         </ExplainerDesktopNav>
       </div>
     </div>
@@ -383,15 +383,17 @@ export function ExplainerMobileNavItem({
 
 export function ExplainerUnitCTA({
   className,
+  href,
   children,
 }: React.PropsWithChildren<{
   className?: string
+  href: string
 }>) {
   return (
-    <div className={clsx('mt-8 flex items-center pl-8 font-medium', className)}>
+    <Link className={clsx('mt-8 flex items-center pl-8 font-medium', className)} href={href}>
       <div>{children}</div>
       <ButtonArrowIcon className="relative -mr-1 h-6 w-6" />
-    </div>
+    </Link>
   )
 }
 


### PR DESCRIPTION
## Summary

- The "LEARN MORE →" CTA in the homepage ExplainerUnit section (data model explainer) was a `<div>` instead of a link — clicking it did nothing
- Changed `ExplainerUnitCTA` to use `<Link>` and pointed it to `/guides/understanding-atproto`

Closes #514

## Test plan

- [x] Visit homepage, scroll to the JSON data model explainer section
- [x] Click "LEARN MORE →" — should navigate to /guides/understanding-atproto

🤖 Generated with [Claude Code](https://claude.com/claude-code)