### PR TITLE
Use the right Tranquil PDS repo link

### DIFF
--- a/src/app/[locale]/guides/self-hosting/en.mdx
+++ b/src/app/[locale]/guides/self-hosting/en.mdx
@@ -24,7 +24,7 @@ For guidance on scaling and hardening a PDS, refer to [Going to Production](/gui
 Bluesky runs many PDSs with an “entryway” in front of them. For information on this implementation, refer to [Entryway](https://docs.bsky.app/docs/advanced-guides/entryway).
 
 There are also several community PDS implementations! For example:
-- [Tranquil PDS](https://tangled.org/lewis.moe/bspds-sandbox), written in Rust.
+- [Tranquil PDS](https://tangled.org/tranquil.farm/tranquil-pds), written in Rust.
 - [Cocoon](https://tangled.org/hailey.at/cocoon), written in Go.
 
 ## Tap

--- a/src/app/[locale]/guides/self-hosting/ja.mdx
+++ b/src/app/[locale]/guides/self-hosting/ja.mdx
@@ -26,7 +26,7 @@ PDSのスケーリングやセキュリティ強化に関する指針につい�
 Blueskyは多くのPDSの前に「entryway」を置いて運用しています。この実装に関する情報は[entryway](https://docs.bsky.app/docs/advanced-guides/entryway)を参照してください。
 
 コミュニティによるPDS実装もあります。例えば、以下があります。
-- [Tranquil PDS](https://tangled.org/lewis.moe/bspds-sandbox)（Rust）
+- [Tranquil PDS](https://tangled.org/tranquil.farm/tranquil-pds)（Rust）
 - [Cocoon](https://tangled.org/hailey.at/cocoon)（Go）
 
 <Heading level={2} id="tap">Tap</Heading>

--- a/src/app/[locale]/guides/self-hosting/ko.mdx
+++ b/src/app/[locale]/guides/self-hosting/ko.mdx
@@ -15,7 +15,7 @@ PDS Docker 이미지에는 관리 기능을 수행하는 명령줄 도구인 [go
 PDS 확장 및 강화에 대한 안내는 [프로덕션 환경 구축](/guides/going-to-production)을 참조하세요.
 Bluesky는 다수의 PDS 앞에 “엔트리웨이(entryway)”를 배치하여 운영합니다. 이 구현 방식에 대한 정보는 [엔트리웨이](https://docs.bsky.app/docs/advanced-guides/entryway)를 참조하세요.
 커뮤니티에서 개발한 PDS 구현체도 여러 가지가 있습니다! 예를 들면:
-- [Tranquil PDS](https://tangled.org/lewis.moe/bspds-sandbox), Rust로 작성됨.
+- [Tranquil PDS](https://tangled.org/tranquil.farm/tranquil-pds), Rust로 작성됨.
 - [Cocoon](https://tangled.org/hailey.at/cocoon), Go로 작성됨.
 ## Tap
 Tap은 AT 네트워크의 기존 레코드를 동기화하고, 이후 파이어호스에서 새로운 레코드를 계속 수신하는 데 사용됩니다. Tap 배포 가이드에 대해서는 [Tap readme](https://github.com/bluesky-social/indigo/blob/main/cmd/tap/README.md#distribution--deployment)를 참조하세요.

--- a/src/app/[locale]/guides/self-hosting/pt.mdx
+++ b/src/app/[locale]/guides/self-hosting/pt.mdx
@@ -15,7 +15,7 @@ Se você precisar alterar o *nome de domínio* de um PDS auto-hospedado, será n
 Para obter orientações sobre como dimensionar e fortalecer um PDS, consulte [Indo para a produção](/guides/going-to-production).
 O Bluesky executa muitos PDSs com uma “entrada” na frente deles. Para obter informações sobre essa implementação, consulte [Entrada](https://docs.bsky.app/docs/advanced-guides/entryway).
 Existem também várias implementações de PDS da comunidade! Por exemplo:
-- [Tranquil PDS](https://tangled.org/lewis.moe/bspds-sandbox), escrito em Rust.
+- [Tranquil PDS](https://tangled.org/tranquil.farm/tranquil-pds), escrito em Rust.
 - [Cocoon](https://tangled.org/hailey.at/cocoon), escrito em Go.
 ## Tap
 O Tap é usado para sincronizar registros existentes da rede AT e, em seguida, continuar recebendo novos registros do firehose. Para obter um guia de implantação do Tap, consulte o [Tap readme](https://github.com/bluesky-social/indigo/blob/main/cmd/tap/README.md#distribution--deployment).


### PR DESCRIPTION
We haven't used the lewis.moe bspds-sandbox repo in about a month now (the repo doesn't even exist anymore). So update the links in the self-hosting guide to use our new repo.