### PR TITLE
fix: update `lang` attribute based on user locale selection

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -39,11 +39,13 @@ export const metadata: Metadata = {
 
 export default async function RootLayout({
   children,
+  params,
 }: {
   children: React.ReactNode
+  params: { locale: string }
 }) {
   return (
-    <html lang="en" className="h-full" suppressHydrationWarning>
+    <html lang={params.locale} className="h-full" suppressHydrationWarning>
       <body className="flex min-h-full bg-white antialiased dark:bg-zinc-900">
         <Providers>
           <div className="w-full">


### PR DESCRIPTION
The `lang` attribute in the layout html tag is currently hard-coded to "en", which should change when the user selects an alternative locale from the dropdown. 

Feel free to close this if hard-coding was intentional until other localizations are added