### PR TITLE
Fix dark mode hardcode for non-en locales

### DIFF
--- a/src/app/[locale]/providers.tsx
+++ b/src/app/[locale]/providers.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react'
 import { ThemeProvider, useTheme } from 'next-themes'
 import { usePathname } from 'next/navigation'
+import { stripLocalePrefix } from '@/components/Navigation'
 
 function ThemeWatcher() {
   let { resolvedTheme, setTheme } = useTheme()
@@ -30,7 +31,7 @@ function ThemeWatcher() {
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
-  const isHome = pathname === '/'
+  const isHome = stripLocalePrefix(pathname) === '/'
 
   return (
     <ThemeProvider

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,6 +15,7 @@ import LanguageChanger from './LanguageChanger'
 import { BlueskyIcon } from './icons/BlueskyIcon'
 import { GithubIcon } from './icons/GithubIcon'
 import { usePathname } from 'next/navigation'
+import { stripLocalePrefix } from '@/components/Navigation'
 
 function TopLevelNavItem({
   className,
@@ -42,7 +43,7 @@ export const Header = forwardRef<
   React.ComponentPropsWithoutRef<typeof motion.div> & { minimal?: boolean }
 >(function Header({ className, minimal, ...props }, ref) {
   const pathname = usePathname()
-  const isHome = pathname === '/'
+  const isHome = stripLocalePrefix(pathname) === '/'
 
   let { isOpen: mobileNavIsOpen } = useMobileNavigationStore()
   let isInsideMobileNavigation = useIsInsideMobileNavigation()


### PR DESCRIPTION
Co-authored by Claude.

The issue was that we hardcode dark mode for main page but don't detect main page correctly.

## Test Plan

System light mode now correctly forces dark mode for `/ja` homepage and such.

<img width="1912" height="1237" alt="Screenshot 2026-02-18 at 01 54 48" src="https://github.com/user-attachments/assets/210bd080-11fc-4b06-b4a5-309362d4de6b" />
