### PR TITLE
Increase color contrast for footer social-link icons

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -109,7 +109,7 @@ function SocialLink({
   return (
     <Link href={href} className="group">
       <span className="sr-only">{children}</span>
-      <Icon className="h-5 w-5 fill-zinc-700 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-500" />
+      <Icon className="h-5 w-5 fill-zinc-600 dark:fill-zinc-400 transition group-hover:fill-zinc-900 dark:group-hover:fill-zinc-500" />
     </Link>
   )
 }


### PR DESCRIPTION
Required to satisfy WCAG 2.1 AA 1.4.3
https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html