### PR TITLE
Replace h2 with span in Navigation component

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -180,9 +180,9 @@ function NavigationGroup({
         className,
       )}
     >
-      <h2 className="px-3 text-xs font-medium uppercase text-slate-500 dark:text-slate-300">
+      <span className="px-3 text-xs font-medium uppercase text-slate-500 dark:text-slate-300">
         {navT(locale, group.title)}
-      </h2>
+      </span>
       <ul role="list" className="border-l border-transparent">
         {group.links.map((link) => {
           const hasChildren = link.links && link.links.length > 0


### PR DESCRIPTION
Required to remain sequentially-descending order.

<img width="340" height="328" alt="image" src="https://github.com/user-attachments/assets/63511636-c34a-4086-ae83-14123cdb502b" />
