### PR TITLE
docs: enhance `goat lex publish` example usage

### DIFF
--- a/src/app/[locale]/guides/publishing-lexicons/en.mdx
+++ b/src/app/[locale]/guides/publishing-lexicons/en.mdx
@@ -39,6 +39,7 @@ $ open ./lexicons/dev/project/thing.json
 And eventually publish it with `goat lex publish`:
 
 ```markdown
+# login with 'goat account login', or provide env vars (GOAT_USERNAME="user.example.com" and GOAT_PASSWORD="...")
 $ goat lex publish
  🟢 dev.project.thing
 ```


### PR DESCRIPTION
Hi there! I was trying to follow [these docs on publishing lexicons](https://atproto.com/guides/publishing-lexicons) and I was briefly confused by the lack of an output when running `goat lex publish`. Turns out, I needed to log in!

I opened https://github.com/bluesky-social/goat/pull/42 to patch up the error handling, but I figured it'd be useful to clarify this in the docs as well. The comment that I added matches the usage docs [in the `goat` CLI repository](https://github.com/bluesky-social/goat/blob/ceb900cac76e860c918fe061aaaa50bdc4434ebe/README.md?plain=1#L233).

Happy to tweak the language as needed. Thanks in advance for the review (and congrats on the recent relaunch of these docs, they're great)!