### PR TITLE
datetime clarification

### DIFF
--- a/src/app/[locale]/specs/lexicon/en.mdx
+++ b/src/app/[locale]/specs/lexicon/en.mdx
@@ -343,9 +343,9 @@ The character separating "date" and "time" parts must be an upper-case `T`.
 
 Timezone specification is required. It is *strongly* preferred to use the UTC timezone, and to represent the timezone with a simple capital `Z` suffix (lower-case is not allowed). While hour/minute suffix syntax (like `+01:00` or `-10:30`) is supported, "negative zero" (`-00:00`) is specifically disallowed (by ISO 8601).
 
-Leap seconds are not supported. The seconds value must be between `00` and `59`. Datetime strings with a seconds value of `60` or higher are invalid. Dates with an invalid month-day combination (eg, April 31st or February 29th in a non-leap year) are also invalid, even if the datetime library being used would auto-correct them into valid datetimes. A month or day with value `00` is invalid.
-
 Whole seconds precision is required, and arbitrary fractional precision digits are allowed. Best practice is to use at least millisecond precision, and to pad with zeros to the generated precision (eg, trailing `:12.340Z` instead of `:12.34Z`). Not all datetime formatting libraries support trailing zero formatting. Both millisecond and microsecond precision have reasonable cross-language support; nanosecond precision does not.
+
+Leap seconds are not supported. The seconds value must be between `00` and `59`. Datetime strings with a seconds value of `60` or higher are invalid. Dates with an invalid month-day combination (eg, April 31st or February 29th in a non-leap year) are also invalid, even if the datetime library being used would auto-correct them into valid datetimes. A month or day with value `00` is invalid.
 
 Implementations should be aware when round-tripping records containing datetimes of three ambiguities: loss-of-precision, ambiguity with trailing fractional second zeros, and timezone normalization. If de-serializing Lexicon records into native types, and then re-serializing, the string representation may not be the same, which could result in broken hash references, sanity check failures, or repository update churn. A safer thing to do is to deserialize the datetime as a simple string, which ensures round-trip re-serialization.
 


### PR DESCRIPTION
The spec does not say anything about the fact that valid `datetime` string need to "_be a valid datetime string that have a normalized value that is also a valid `datettime` string_", only that the string must comply to RFC 3339, ISO 8601, and WHATWG HTML.

As such dates, any `datetime` like `0000-01-01T00:00:00+23:59` or `9999-12-31T23:59:59.999-23:59` should be considered valid.

Similarly, the spec does not say anything about leap seconds and leap years. Since this is an area where implementation will differ (e.g. javascript allows `new Date('2015-02-29')`, but won't allow leap seconds), we should make it explicit how to handle these cases.

I've used the "least common denominator" here:
- ensure that the mday matches the month (based on the year), so that invalid mday are considered invalid, even if the implementation supports/corrects them
- reject leap seconds (since not all implementation support them)

Related to:

- [x] https://github.com/bluesky-social/atproto/pull/4758
- [x] https://github.com/bluesky-social/atproto-interop-tests/pull/13
- [ ] ingido
- [ ] comms
