### PR TITLE
label guide: note the 'bot' self-label value

### DIFF
--- a/src/app/[locale]/guides/labels/en.mdx
+++ b/src/app/[locale]/guides/labels/en.mdx
@@ -47,6 +47,7 @@ There are a few label values which are defined by the protocol. They are:
 - `sexual` which behaves like `porn` but is meant to handle less intense sexual content.
 - `graphic-media` which behaves like `porn` but is for violence / gore.
 - `nudity` which puts a warning on images but isn't 18+ and defaults to ignore.
+- `bot` which indicates than an account is automated.
 
 There are two reasons global label values exist.
 


### PR DESCRIPTION
This is sort of documenting a bsky-specific label in the context of the overall protocol, which isn't great. But this is a place devs will look for documentation, and I do expect/assume this would be a value others would use in other apps.