### PR TITLE
Consolidate blog scripts under a single entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,28 @@ The page auto-updates as you edit the file.
 
 ---
 
-### Creating a new blog post
+### Blog tools
 
-Run the blog post generator:
+All blog-related commands are available through a single entry point:
 
 ```bash
-npm run blog
+npm run blog <command>
+```
+
+| Command | Description |
+|---------|-------------|
+| `npm run blog create` | Create a new blog post |
+| `npm run blog remove` | Remove a blog post |
+| `npm run blog ssite <slug>` | Publish a post as a standard-site record |
+| `npm run blog hide-reply <url>` | Hide a reply or detach a quote post |
+| `npm run blog create-publication` | Create the publication record (one-time setup) |
+
+Run `npm run blog` with no arguments to see this list.
+
+### Creating a new blog post
+
+```bash
+npm run blog create
 ```
 
 This will prompt you for:
@@ -48,7 +64,7 @@ When creating a new post, if the author name isn't found in the registry, the sc
 ### Removing a blog post
 
 ```bash
-npm run rmblog
+npm run blog remove
 ```
 
 This displays a paginated list of blog posts (10 at a time, most recent first). Select a post by number to remove it. The script will:
@@ -82,23 +98,23 @@ Blog posts can be published to the AT Protocol using the [site.standard](https:/
 
 2. **Create the publication record:**
    ```bash
-   npm run create-publication
+   npm run blog create-publication
    ```
    Save the returned AT-URI to your `.env` as `ATPROTO_PUBLICATION_URI`.
 
 #### Publishing a post
 
 ```bash
-npm run publish-post <slug>
+npm run blog ssite <slug>
 ```
 
 For example:
 ```bash
-npm run publish-post welcome-to-the-blog
+npm run blog ssite welcome-to-the-blog
 ```
 
 This will:
-- Create a `site.standard.document` record on your PDS
+- Create a `standard.site` document record on your PDS
 - Save the AT-URI back to the post's MDX file for verification
 - Update the record if it already exists
 
@@ -241,10 +257,10 @@ The `hide-reply` script lets you hide replies or detach quote posts from the con
 
 ```bash
 # Hide a reply (adds to threadgate hiddenReplies)
-npm run hide-reply https://bsky.app/profile/did:plc:.../post/...
+npm run blog hide-reply https://bsky.app/profile/did:plc:.../post/...
 
 # Detach a quote post (adds to postgate detachedEmbeddingUris)
-npm run hide-reply https://bsky.app/profile/did:plc:.../post/...
+npm run blog hide-reply https://bsky.app/profile/did:plc:.../post/...
 ```
 
 Requires `ATPROTO_HANDLE` and `ATPROTO_APP_PASSWORD` in `.env`. The authenticated user must own the root post being replied to or quoted.

--- a/package.json
+++ b/package.json
@@ -7,11 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "blog": "node scripts/new-blog-post.mjs",
-    "rmblog": "node scripts/remove-blog-post.mjs",
-    "create-publication": "tsx --env-file=.env scripts/create-publication.mjs",
-    "publish-post": "tsx --env-file=.env scripts/publish-post.mjs",
-    "hide-reply": "tsx --env-file=.env scripts/hide-reply.mjs",
+    "blog": "tsx --env-file=.env scripts/blog.mjs",
     "pages:build": "npx @cloudflare/next-on-pages",
     "preview": "npm run pages:build && wrangler pages dev",
     "deploy": "npm run pages:build && wrangler pages deploy"

--- a/scripts/blog.mjs
+++ b/scripts/blog.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+const command = process.argv[2]
+const arg = process.argv[3]
+
+const commands = {
+  create: {
+    description: 'Create a new blog post',
+    run: () => import('./new-blog-post.mjs').then((m) => m.main()),
+  },
+  remove: {
+    description: 'Remove a blog post',
+    run: () => import('./remove-blog-post.mjs').then((m) => m.main()),
+  },
+  ssite: {
+    description: 'Publish a post as a standard-site record',
+    usage: '<slug>',
+    run: () => import('./publish-post.mjs').then((m) => m.main(arg)),
+  },
+  'hide-reply': {
+    description: 'Hide a reply or detach a quote post',
+    usage: '<post-url>',
+    run: () => import('./hide-reply.mjs').then((m) => m.main(arg)),
+  },
+  'create-publication': {
+    description: 'Create the standard-site publication record (one-time setup)',
+    run: () => import('./create-publication.mjs').then((m) => m.main()),
+  },
+}
+
+if (!command || !commands[command]) {
+  console.log('\nUsage: npm run blog <command>\n')
+  console.log('Commands:')
+  for (const [name, cmd] of Object.entries(commands)) {
+    const usage = cmd.usage ? ` ${cmd.usage}` : ''
+    console.log(`  ${name}${usage}`.padEnd(32) + cmd.description)
+  }
+  console.log('')
+  process.exit(command ? 1 : 0)
+}
+
+commands[command].run().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/scripts/create-publication.mjs
+++ b/scripts/create-publication.mjs
@@ -21,7 +21,7 @@ const PUBLICATION_NAME = 'AT Protocol'
 const PUBLICATION_DESCRIPTION =
   'Documentation, guides, and updates for the AT Protocol - the decentralized foundation for social networking.'
 
-async function main() {
+export async function main() {
   const { ATPROTO_HANDLE, ATPROTO_APP_PASSWORD, ATPROTO_PDS_URL } = process.env
 
   if (!ATPROTO_HANDLE || !ATPROTO_APP_PASSWORD) {
@@ -88,7 +88,3 @@ async function main() {
   console.log(`\n   Add this to your .env file.`)
 }
 
-main().catch((err) => {
-  console.error('Unexpected error:', err)
-  process.exit(1)
-})

--- a/scripts/hide-reply.mjs
+++ b/scripts/hide-reply.mjs
@@ -65,12 +65,10 @@ function findQuotedUri(post, ownerDid) {
   return null
 }
 
-async function main() {
-  const postUrl = process.argv[2]
-
+export async function main(postUrl) {
   if (!postUrl) {
-    console.error('Usage: npm run hide-reply <post-url>')
-    console.error('Example: npm run hide-reply https://bsky.app/profile/did:plc:.../post/...')
+    console.error('Usage: npm run blog hide-reply <post-url>')
+    console.error('Example: npm run blog hide-reply https://bsky.app/profile/did:plc:.../post/...')
     process.exit(1)
   }
 
@@ -249,7 +247,3 @@ async function detachQuote(client, session, quotedUri, quoteUri) {
   console.log(`   Detached quotes: ${record.detachedEmbeddingUris.length}`)
 }
 
-main().catch((err) => {
-  console.error('Unexpected error:', err)
-  process.exit(1)
-})

--- a/scripts/new-blog-post.mjs
+++ b/scripts/new-blog-post.mjs
@@ -68,7 +68,7 @@ function createBranch(slug) {
   }
 }
 
-async function main() {
+export async function main() {
   console.log('\n📝 Create a new blog post\n')
 
   const shouldCreateBranch = await checkGitStatus()
@@ -191,7 +191,3 @@ Next steps:
 `)
 }
 
-main().catch((err) => {
-  console.error(err)
-  process.exit(1)
-})

--- a/scripts/publish-post.mjs
+++ b/scripts/publish-post.mjs
@@ -137,12 +137,10 @@ function parseDate(dateStr) {
   return date.toISOString()
 }
 
-async function main() {
-  const slug = process.argv[2]
-
+export async function main(slug) {
   if (!slug) {
-    console.error('Usage: npm run publish-post <slug>')
-    console.error('Example: npm run publish-post welcome-to-the-blog')
+    console.error('Usage: npm run blog ssite <slug>')
+    console.error('Example: npm run blog ssite welcome-to-the-blog')
     process.exit(1)
   }
 
@@ -276,7 +274,3 @@ async function main() {
   console.log(`\n📎 Saved AT-URI to ${path.basename(mdxPath)}`)
 }
 
-main().catch((err) => {
-  console.error('Unexpected error:', err)
-  process.exit(1)
-})

--- a/scripts/remove-blog-post.mjs
+++ b/scripts/remove-blog-post.mjs
@@ -68,7 +68,7 @@ function removePostDirectory(slug) {
   return false
 }
 
-async function main() {
+export async function main() {
   const posts = parsePosts()
 
   if (posts.length === 0) {
@@ -139,7 +139,3 @@ async function main() {
   rl.close()
 }
 
-main().catch((err) => {
-  console.error(err)
-  process.exit(1)
-})


### PR DESCRIPTION
All blog-related commands now run through `npm run blog <command>`:
create, remove, ssite, hide-reply, create-publication.
