### PR TITLE
Fix typo in account migration guide

### DIFF
--- a/src/app/[locale]/guides/account-migration/en.mdx
+++ b/src/app/[locale]/guides/account-migration/en.mdx
@@ -14,7 +14,7 @@ For an in-depth explanation of the steps involved in a migration, read on.
 
 ## Creating a New Account
 
-To create a PDS account with an existing identity, it is necessary to prove control the identity.
+To create a PDS account with an existing identity, it is necessary to prove control of the identity.
 
 For an active account on another PDS, this is done by generating a service auth token (JWT) signed with the current atproto signing key indicated in the identity DID document. This can be requested from the previous PDS instance using the `com.atproto.server.getServiceAuth` endpoint (or an equivalent interface/API).
 


### PR DESCRIPTION
I fixed a minor typo in migration guide. 

I didn't see any `CONTRIBUTING.md` so I'm not entirely sure if there are any specific requirements for PRs. Let me know if there's anything I need to do, e.g., open an issue.