### PR TITLE
ssite doc contributor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ node_modules
 .claude
 .superpowers
 docs/superpowers
+oauth-test
 src/lexicons
 tsconfig.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ node_modules
 .DS_Store
 .env
 .claude
+.superpowers
+docs/superpowers
 src/lexicons
 tsconfig.tsbuildinfo

--- a/lexicons.json
+++ b/lexicons.json
@@ -5,21 +5,25 @@
     "site.standard.publication"
   ],
   "resolutions": {
+    "com.atproto.label.defs": {
+      "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.label.defs",
+      "cid": "bafyreidp2wpcbzl2qiob2uwoc7lhntojx3tjcr553mmahw2f5cumtm3wpm"
+    },
     "com.atproto.repo.strongRef": {
       "uri": "at://did:plc:6msi3pj7krzih5qxqtryxlzw/com.atproto.lexicon.schema/com.atproto.repo.strongRef",
       "cid": "bafyreifrkdbnkvfjujntdaeigolnrjj3srrs53tfixjhmacclps72qlov4"
     },
     "site.standard.document": {
       "uri": "at://did:plc:re3ebnp5v7ffagz6rb6xfei4/com.atproto.lexicon.schema/site.standard.document",
-      "cid": "bafyreifzalrdierm2q4yddul2dn7ei2x2znmucsejxa6aeppklecrt745q"
+      "cid": "bafyreifylc5lfr4vqfzrwdtqm4pnfg7cbra7z4acbgikylqandzefwdeaq"
     },
     "site.standard.publication": {
       "uri": "at://did:plc:re3ebnp5v7ffagz6rb6xfei4/com.atproto.lexicon.schema/site.standard.publication",
-      "cid": "bafyreigrsjktb6o225aoexib4kmckchzlhbnuckj5t3l6k4asmycrjt5vy"
+      "cid": "bafyreiapvnarfn3nl2wvg27hsylli5zqvou7a74p7od5mu4detprtejapy"
     },
     "site.standard.theme.basic": {
       "uri": "at://did:plc:re3ebnp5v7ffagz6rb6xfei4/com.atproto.lexicon.schema/site.standard.theme.basic",
-      "cid": "bafyreicgo6eszo6fgz6rpdc2wt4ou3dem65hkqagzgaw4xbl32i2ttdu3q"
+      "cid": "bafyreiabm6f64zosv5jcdmwd3qvekjhoi7enevg53rxj734ney4sd6lmku"
     },
     "site.standard.theme.color": {
       "uri": "at://did:plc:re3ebnp5v7ffagz6rb6xfei4/com.atproto.lexicon.schema/site.standard.theme.color",

--- a/lexicons/com/atproto/label/defs.json
+++ b/lexicons/com/atproto/label/defs.json
@@ -1,0 +1,190 @@
+{
+  "id": "com.atproto.label.defs",
+  "defs": {
+    "label": {
+      "type": "object",
+      "required": [
+        "src",
+        "uri",
+        "val",
+        "cts"
+      ],
+      "properties": {
+        "cid": {
+          "type": "string",
+          "format": "cid",
+          "description": "Optionally, CID specifying the specific version of 'uri' resource this label applies to."
+        },
+        "cts": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp when this label was created."
+        },
+        "exp": {
+          "type": "string",
+          "format": "datetime",
+          "description": "Timestamp at which this label expires (no longer applies)."
+        },
+        "neg": {
+          "type": "boolean",
+          "description": "If true, this is a negation label, overwriting a previous label."
+        },
+        "sig": {
+          "type": "bytes",
+          "description": "Signature of dag-cbor encoded label."
+        },
+        "src": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the actor who created this label."
+        },
+        "uri": {
+          "type": "string",
+          "format": "uri",
+          "description": "AT URI of the record, repository (account), or other resource that this label applies to."
+        },
+        "val": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "The short string name of the value or type of this label."
+        },
+        "ver": {
+          "type": "integer",
+          "description": "The AT Protocol version of the label object."
+        }
+      },
+      "description": "Metadata tag on an atproto resource (eg, repo or record)."
+    },
+    "selfLabel": {
+      "type": "object",
+      "required": [
+        "val"
+      ],
+      "properties": {
+        "val": {
+          "type": "string",
+          "maxLength": 128,
+          "description": "The short string name of the value or type of this label."
+        }
+      },
+      "description": "Metadata tag on an atproto record, published by the author within the record. Note that schemas should use #selfLabels, not #selfLabel."
+    },
+    "labelValue": {
+      "type": "string",
+      "knownValues": [
+        "!hide",
+        "!warn",
+        "!no-unauthenticated",
+        "porn",
+        "sexual",
+        "nudity",
+        "graphic-media",
+        "bot"
+      ]
+    },
+    "selfLabels": {
+      "type": "object",
+      "required": [
+        "values"
+      ],
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "ref": "#selfLabel",
+            "type": "ref"
+          },
+          "maxLength": 10
+        }
+      },
+      "description": "Metadata tags on an atproto record, published by the author within the record."
+    },
+    "labelValueDefinition": {
+      "type": "object",
+      "required": [
+        "identifier",
+        "severity",
+        "blurs",
+        "locales"
+      ],
+      "properties": {
+        "blurs": {
+          "type": "string",
+          "description": "What should this label hide in the UI, if applied? 'content' hides all of the target; 'media' hides the images/video/audio; 'none' hides nothing.",
+          "knownValues": [
+            "content",
+            "media",
+            "none"
+          ]
+        },
+        "locales": {
+          "type": "array",
+          "items": {
+            "ref": "#labelValueDefinitionStrings",
+            "type": "ref"
+          }
+        },
+        "severity": {
+          "type": "string",
+          "description": "How should a client visually convey this label? 'inform' means neutral and informational; 'alert' means negative and warning; 'none' means show nothing.",
+          "knownValues": [
+            "inform",
+            "alert",
+            "none"
+          ]
+        },
+        "adultOnly": {
+          "type": "boolean",
+          "description": "Does the user need to have adult content enabled in order to configure this label?"
+        },
+        "identifier": {
+          "type": "string",
+          "maxLength": 100,
+          "description": "The value of the label being defined. Must only include lowercase ascii and the '-' character ([a-z-]+).",
+          "maxGraphemes": 100
+        },
+        "defaultSetting": {
+          "type": "string",
+          "default": "warn",
+          "description": "The default setting for this label.",
+          "knownValues": [
+            "ignore",
+            "warn",
+            "hide"
+          ]
+        }
+      },
+      "description": "Declares a label value and its expected interpretations and behaviors."
+    },
+    "labelValueDefinitionStrings": {
+      "type": "object",
+      "required": [
+        "lang",
+        "name",
+        "description"
+      ],
+      "properties": {
+        "lang": {
+          "type": "string",
+          "format": "language",
+          "description": "The code of the language these strings are written in."
+        },
+        "name": {
+          "type": "string",
+          "maxLength": 640,
+          "description": "A short human-readable name for the label.",
+          "maxGraphemes": 64
+        },
+        "description": {
+          "type": "string",
+          "maxLength": 100000,
+          "description": "A longer description of what the label means and why it might be applied.",
+          "maxGraphemes": 10000
+        }
+      },
+      "description": "Strings which describe the label in the UI, localized into a specific language."
+    }
+  },
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1
+}

--- a/lexicons/site/standard/document.json
+++ b/lexicons/site/standard/document.json
@@ -30,11 +30,23 @@
             },
             "description": "Array of strings used to tag or categorize the document. Avoid prepending tags with hashtags."
           },
+          "links": {
+            "refs": [],
+            "type": "union",
+            "description": "Array of values describing relationships between this document and external resources"
+          },
           "title": {
             "type": "string",
             "maxLength": 5000,
             "description": "Title of the document.",
             "maxGraphemes": 500
+          },
+          "labels": {
+            "refs": [
+              "com.atproto.label.defs#selfLabels"
+            ],
+            "type": "union",
+            "description": "Self-label values for this post. Effectively content warnings."
           },
           "content": {
             "refs": [],
@@ -74,10 +86,39 @@
           "textContent": {
             "type": "string",
             "description": "Plaintext representation of the documents contents. Should not contain markdown or other formatting."
+          },
+          "contributors": {
+            "type": "array",
+            "items": {
+              "ref": "#contributor",
+              "type": "ref"
+            }
           }
         }
       },
       "description": "A document record representing a published article, blog post, or other content. Documents can belong to a publication or exist independently."
+    },
+    "contributor": {
+      "type": "object",
+      "required": [
+        "did"
+      ],
+      "properties": {
+        "did": {
+          "type": "string",
+          "format": "did"
+        },
+        "role": {
+          "type": "string",
+          "maxLength": 1000,
+          "maxGraphemes": 100
+        },
+        "displayName": {
+          "type": "string",
+          "maxLength": 1000,
+          "maxGraphemes": 100
+        }
+      }
     }
   },
   "$type": "com.atproto.lexicon.schema",

--- a/lexicons/site/standard/publication.json
+++ b/lexicons/site/standard/publication.json
@@ -30,6 +30,13 @@
             "description": "Name of the publication.",
             "maxGraphemes": 500
           },
+          "labels": {
+            "refs": [
+              "com.atproto.label.defs#selfLabels"
+            ],
+            "type": "union",
+            "description": "Self-label values for this publication. Effectively content warnings."
+          },
           "basicTheme": {
             "ref": "site.standard.theme.basic",
             "type": "ref",
@@ -58,8 +65,7 @@
           "default": true,
           "description": "Boolean which decides whether the publication should appear in discovery feeds."
         }
-      },
-      "description": "Platform-specific preferences for the publication, including discovery and visibility settings."
+      }
     }
   },
   "$type": "com.atproto.lexicon.schema",

--- a/lexicons/site/standard/theme/basic.json
+++ b/lexicons/site/standard/theme/basic.json
@@ -2,41 +2,45 @@
   "id": "site.standard.theme.basic",
   "defs": {
     "main": {
-      "type": "object",
-      "required": [
-        "background",
-        "foreground",
-        "accent",
-        "accentForeground"
-      ],
-      "properties": {
-        "accent": {
-          "refs": [
-            "site.standard.theme.color#rgb"
-          ],
-          "type": "union",
-          "description": "Color used for links and button backgrounds."
-        },
-        "background": {
-          "refs": [
-            "site.standard.theme.color#rgb"
-          ],
-          "type": "union",
-          "description": "Color used for content background."
-        },
-        "foreground": {
-          "refs": [
-            "site.standard.theme.color#rgb"
-          ],
-          "type": "union",
-          "description": "Color used for content text."
-        },
-        "accentForeground": {
-          "refs": [
-            "site.standard.theme.color#rgb"
-          ],
-          "type": "union",
-          "description": "Color used for button text."
+      "key": "tid",
+      "type": "record",
+      "record": {
+        "type": "object",
+        "required": [
+          "background",
+          "foreground",
+          "accent",
+          "accentForeground"
+        ],
+        "properties": {
+          "accent": {
+            "refs": [
+              "site.standard.theme.color#rgb"
+            ],
+            "type": "union",
+            "description": "Color used for links and button backgrounds."
+          },
+          "background": {
+            "refs": [
+              "site.standard.theme.color#rgb"
+            ],
+            "type": "union",
+            "description": "Color used for content background."
+          },
+          "foreground": {
+            "refs": [
+              "site.standard.theme.color#rgb"
+            ],
+            "type": "union",
+            "description": "Color used for content text."
+          },
+          "accentForeground": {
+            "refs": [
+              "site.standard.theme.color#rgb"
+            ],
+            "type": "union",
+            "description": "Color used for button text."
+          }
         }
       },
       "description": "A simplified theme definition for publications, providing basic color customization for content display across different platforms and applications."

--- a/scripts/blog.mjs
+++ b/scripts/blog.mjs
@@ -32,6 +32,15 @@ const commands = {
     usage: '[--apply]',
     run: () => import('./migrate-paths.mjs').then((m) => m.main(...extraArgs)),
   },
+  'migrate-contributors-and-refs': {
+    description:
+      'Backfill contributors + bskyPostRef on existing standard-site records (one-off)',
+    usage: '[--apply]',
+    run: () =>
+      import('./migrate-contributors-and-refs.mjs').then((m) =>
+        m.main(...extraArgs),
+      ),
+  },
 }
 
 if (!command || !commands[command]) {

--- a/scripts/create-publication.mjs
+++ b/scripts/create-publication.mjs
@@ -21,6 +21,20 @@ const PUBLICATION_NAME = 'AT Protocol'
 const PUBLICATION_DESCRIPTION =
   'Documentation, guides, and updates for the AT Protocol - the decentralized foundation for social networking.'
 
+const rgb = (r, g, b) => ({
+  $type: 'site.standard.theme.color#rgb',
+  r,
+  g,
+  b,
+})
+
+const BASIC_THEME = {
+  background: rgb(255, 255, 255),
+  foreground: rgb(24, 24, 27),
+  accent: rgb(234, 179, 8),
+  accentForeground: rgb(24, 24, 27),
+}
+
 export async function main() {
   const { ATPROTO_HANDLE, ATPROTO_APP_PASSWORD, ATPROTO_PDS_URL } = process.env
 
@@ -78,6 +92,7 @@ export async function main() {
     preferences: {
       showInDiscover: true,
     },
+    basicTheme: BASIC_THEME,
   })
 
   console.log('\n✅ Publication created successfully!\n')

--- a/scripts/lib/buildContributors.mjs
+++ b/scripts/lib/buildContributors.mjs
@@ -1,0 +1,19 @@
+// scripts/lib/buildContributors.mjs
+
+/**
+ * Maps a blog post's `author` header string to a `contributors[]` array
+ * for site.standard.document records.
+ *
+ * Throws if the name has no entry in `authors`. The migration script
+ * and publish-post.mjs both rely on this fail-loud behavior so a stray
+ * author name can't quietly produce contributor-less records.
+ */
+export function buildContributors(authorName, authors) {
+  const did = authors[authorName]
+  if (!did) {
+    throw new Error(
+      `Unknown author: ${authorName}. Add an entry to src/lib/authors.json.`,
+    )
+  }
+  return [{ did, displayName: authorName, role: 'author' }]
+}

--- a/scripts/lib/buildContributors.test.mjs
+++ b/scripts/lib/buildContributors.test.mjs
@@ -1,0 +1,33 @@
+// scripts/lib/buildContributors.test.mjs
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildContributors } from './buildContributors.mjs'
+
+const authors = {
+  'Jim Ray': 'did:plc:lysqukqdu6hsrhet5v2brjgo',
+  'AT Protocol Team': 'did:plc:ewvi7nxzyoun6zhxrhs64oiz',
+}
+
+test('builds a single-author contributors array', () => {
+  const out = buildContributors('Jim Ray', authors)
+  assert.deepEqual(out, [
+    {
+      did: 'did:plc:lysqukqdu6hsrhet5v2brjgo',
+      displayName: 'Jim Ray',
+      role: 'author',
+    },
+  ])
+})
+
+test('preserves displayName for team identities', () => {
+  const out = buildContributors('AT Protocol Team', authors)
+  assert.deepEqual(out[0].displayName, 'AT Protocol Team')
+  assert.equal(out[0].did, 'did:plc:ewvi7nxzyoun6zhxrhs64oiz')
+})
+
+test('throws on unknown author', () => {
+  assert.throws(
+    () => buildContributors('Nobody', authors),
+    /unknown author: Nobody/i,
+  )
+})

--- a/scripts/lib/parseBskyUrl.mjs
+++ b/scripts/lib/parseBskyUrl.mjs
@@ -1,0 +1,25 @@
+// scripts/lib/parseBskyUrl.mjs
+
+/**
+ * Parses a bsky.app post URL into its identifier and rkey.
+ *
+ * Accepts both handle-form (`/profile/atproto.com/...`) and DID-form
+ * (`/profile/did:plc:.../...`) URLs. Returns the literal `handleOrDid`
+ * string; the caller resolves handles to DIDs separately when needed.
+ */
+export function parseBskyUrl(url) {
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch {
+    throw new Error(`Invalid URL: ${url}`)
+  }
+  if (parsed.hostname !== 'bsky.app') {
+    throw new Error(`Not a bsky.app post URL: ${url}`)
+  }
+  const match = parsed.pathname.match(/^\/profile\/([^/]+)\/post\/([^/]+)\/?$/)
+  if (!match) {
+    throw new Error(`Missing rkey in bsky URL: ${url}`)
+  }
+  return { handleOrDid: match[1], rkey: match[2] }
+}

--- a/scripts/lib/parseBskyUrl.test.mjs
+++ b/scripts/lib/parseBskyUrl.test.mjs
@@ -1,0 +1,33 @@
+// scripts/lib/parseBskyUrl.test.mjs
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseBskyUrl } from './parseBskyUrl.mjs'
+
+test('parses DID-form URL', () => {
+  const out = parseBskyUrl(
+    'https://bsky.app/profile/did:plc:ewvi7nxzyoun6zhxrhs64oiz/post/3mhjb5565us2t',
+  )
+  assert.deepEqual(out, {
+    handleOrDid: 'did:plc:ewvi7nxzyoun6zhxrhs64oiz',
+    rkey: '3mhjb5565us2t',
+  })
+})
+
+test('parses handle-form URL', () => {
+  const out = parseBskyUrl('https://bsky.app/profile/atproto.com/post/3mhtaxg4ppk2v')
+  assert.deepEqual(out, { handleOrDid: 'atproto.com', rkey: '3mhtaxg4ppk2v' })
+})
+
+test('throws on non-bsky URL', () => {
+  assert.throws(
+    () => parseBskyUrl('https://example.com/post/abc'),
+    /not a bsky\.app post URL/i,
+  )
+})
+
+test('throws on bsky URL without /post/<rkey>', () => {
+  assert.throws(
+    () => parseBskyUrl('https://bsky.app/profile/atproto.com'),
+    /missing rkey/i,
+  )
+})

--- a/scripts/lib/resolveBskyPostRef.mjs
+++ b/scripts/lib/resolveBskyPostRef.mjs
@@ -1,0 +1,48 @@
+// scripts/lib/resolveBskyPostRef.mjs
+import { parseBskyUrl } from './parseBskyUrl.mjs'
+
+const PUBLIC_API = 'https://public.api.bsky.app/xrpc'
+
+/**
+ * Resolves a bsky.app post URL to a com.atproto.repo.strongRef
+ * ({ uri, cid }) via the public AppView XRPC endpoints.
+ *
+ * The returned `uri` is always at://<did>/app.bsky.feed.post/<rkey>,
+ * so the strongRef stays valid even if the author's handle changes.
+ */
+export async function resolveBskyPostRef(url) {
+  const { handleOrDid, rkey } = parseBskyUrl(url)
+
+  let did
+  if (handleOrDid.startsWith('did:')) {
+    did = handleOrDid
+  } else {
+    const res = await fetch(
+      `${PUBLIC_API}/com.atproto.identity.resolveHandle?handle=${encodeURIComponent(handleOrDid)}`,
+    )
+    if (!res.ok) {
+      throw new Error(
+        `resolveHandle failed for ${handleOrDid}: HTTP ${res.status}`,
+      )
+    }
+    did = (await res.json()).did
+  }
+
+  const res = await fetch(
+    `${PUBLIC_API}/com.atproto.repo.getRecord` +
+      `?repo=${encodeURIComponent(did)}` +
+      `&collection=app.bsky.feed.post` +
+      `&rkey=${encodeURIComponent(rkey)}`,
+  )
+  if (!res.ok) {
+    throw new Error(
+      `getRecord failed for ${did}/${rkey}: HTTP ${res.status}`,
+    )
+  }
+  const record = await res.json()
+  return {
+    $type: 'com.atproto.repo.strongRef',
+    uri: record.uri,
+    cid: record.cid,
+  }
+}

--- a/scripts/migrate-contributors-and-refs.mjs
+++ b/scripts/migrate-contributors-and-refs.mjs
@@ -165,6 +165,40 @@ export async function main(...args) {
     return
   }
 
-  // (Apply branch implemented in Task 10.)
-  console.log('\n(--apply not yet wired; implemented in next task)')
+  console.log('\n📤 Applying changes...\n')
+  let updated = 0
+  let failed = 0
+  let mdxRewritten = 0
+
+  for (const p of plans) {
+    try {
+      const result = await client.put(standard.document.main, p.next, {
+        rkey: p.rkey,
+      })
+      console.log(`  ✓ record ${result.uri}`)
+      updated++
+    } catch (err) {
+      console.error(`  ✗ ${p.post.slug}  record put failed: ${err.message}`)
+      failed++
+      continue
+    }
+
+    if (p.normalizedUrl && p.normalizedUrl !== p.post.blueskyPostUrl) {
+      const next = normalizeBlueskyPostUrlInMdx(
+        p.post.content,
+        p.post.blueskyPostUrl,
+        p.normalizedUrl,
+      )
+      if (next !== p.post.content) {
+        fs.writeFileSync(p.post.mdxPath, next)
+        console.log(`    ✎ MDX URL normalized in ${path.basename(path.dirname(p.post.mdxPath))}/en.mdx`)
+        mdxRewritten++
+      }
+    }
+  }
+
+  console.log(
+    `\n✅ Done. Updated ${updated} record(s), rewrote ${mdxRewritten} MDX file(s), failed ${failed}.`,
+  )
+  if (failed > 0) process.exit(1)
 }

--- a/scripts/migrate-contributors-and-refs.mjs
+++ b/scripts/migrate-contributors-and-refs.mjs
@@ -52,8 +52,11 @@ function listBlogPosts() {
 
 function normalizeBlueskyPostUrlInMdx(content, currentUrl, newUrl) {
   if (currentUrl === newUrl) return content
+  // Match single/double/backtick quotes around the URL; readHeaderField
+  // accepts all three so the rewriter has to as well.
+  const escaped = currentUrl.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
   return content.replace(
-    `blueskyPostUrl: '${currentUrl}'`,
+    new RegExp(`blueskyPostUrl:\\s*(['"\`])${escaped}\\1`),
     `blueskyPostUrl: '${newUrl}'`,
   )
 }
@@ -137,7 +140,6 @@ export async function main(...args) {
       ...existing.value,
       contributors,
       ...(bskyPostRef ? { bskyPostRef } : {}),
-      updatedAt: new Date().toISOString(),
     }
 
     plans.push({ post, rkey, existing: existing.value, next, normalizedUrl })
@@ -172,9 +174,11 @@ export async function main(...args) {
 
   for (const p of plans) {
     try {
-      const result = await client.put(standard.document.main, p.next, {
-        rkey: p.rkey,
-      })
+      const result = await client.put(
+        standard.document.main,
+        { ...p.next, updatedAt: new Date().toISOString() },
+        { rkey: p.rkey },
+      )
       console.log(`  ✓ record ${result.uri}`)
       updated++
     } catch (err) {

--- a/scripts/migrate-contributors-and-refs.mjs
+++ b/scripts/migrate-contributors-and-refs.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+/**
+ * One-off migration: backfills `contributors` and `bskyPostRef` on
+ * existing site.standard.document records, and normalizes MDX
+ * `blueskyPostUrl` values to DID form.
+ *
+ *   npm run blog migrate-contributors-and-refs            # dry run
+ *   npm run blog migrate-contributors-and-refs -- --apply # write
+ */
+
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+import { Client } from '@atproto/lex'
+import { PasswordSession } from '@atproto/lex-password-session'
+import * as siteModule from '../src/lexicons/site.ts'
+import authors from '../src/lib/authors.json' with { type: 'json' }
+import { parseBskyUrl } from './lib/parseBskyUrl.mjs'
+import { resolveBskyPostRef } from './lib/resolveBskyPostRef.mjs'
+import { buildContributors } from './lib/buildContributors.mjs'
+
+const { standard } = siteModule.default ?? siteModule
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const BLOG_DIR = path.join(__dirname, '../src/app/[locale]/blog')
+
+export async function main(...args) {
+  const apply = args.includes('--apply')
+  const mode = apply ? 'APPLY' : 'DRY-RUN'
+
+  const { ATPROTO_HANDLE, ATPROTO_APP_PASSWORD, ATPROTO_PDS_URL, ATPROTO_PUBLICATION_URI } =
+    process.env
+
+  if (!ATPROTO_HANDLE || !ATPROTO_APP_PASSWORD) {
+    console.error('Error: Missing ATPROTO_HANDLE / ATPROTO_APP_PASSWORD in .env')
+    process.exit(1)
+  }
+
+  const service = ATPROTO_PDS_URL || 'https://bsky.social'
+
+  console.log(`\n🔧 Migrate contributors + bskyPostRef (${mode})\n`)
+  console.log(`  Service: ${service}`)
+  console.log(`  Handle:  ${ATPROTO_HANDLE}`)
+
+  const session = await PasswordSession.create({
+    service,
+    identifier: ATPROTO_HANDLE,
+    password: ATPROTO_APP_PASSWORD,
+    onUpdated: () => {},
+    onDeleted: () => {},
+  })
+  const client = new Client(session)
+  console.log(`✓ Authenticated as ${session.handle} (${session.did})`)
+
+  if (ATPROTO_PUBLICATION_URI) {
+    const expectedDid = ATPROTO_PUBLICATION_URI.match(/^at:\/\/([^/]+)/)?.[1]
+    if (expectedDid && expectedDid !== session.did) {
+      console.error(
+        `\n❌ Refusing to run: authenticated DID ${session.did} ≠ publication DID ${expectedDid}`,
+      )
+      process.exit(1)
+    }
+  }
+
+  // (Walk + compute + apply implemented in Task 9.)
+  console.log('\n(scaffold only; walk implemented in next task)')
+}

--- a/scripts/migrate-contributors-and-refs.mjs
+++ b/scripts/migrate-contributors-and-refs.mjs
@@ -16,13 +16,47 @@ import { Client } from '@atproto/lex'
 import { PasswordSession } from '@atproto/lex-password-session'
 import * as siteModule from '../src/lexicons/site.ts'
 import authors from '../src/lib/authors.json' with { type: 'json' }
-import { parseBskyUrl } from './lib/parseBskyUrl.mjs'
 import { resolveBskyPostRef } from './lib/resolveBskyPostRef.mjs'
 import { buildContributors } from './lib/buildContributors.mjs'
 
 const { standard } = siteModule.default ?? siteModule
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const BLOG_DIR = path.join(__dirname, '../src/app/[locale]/blog')
+
+function readHeaderField(content, field) {
+  const re = new RegExp(`^\\s*${field}:\\s*['"\`]([^'"\`]*)['"\`]`, 'm')
+  return content.match(re)?.[1]
+}
+
+function listBlogPosts() {
+  const entries = fs.readdirSync(BLOG_DIR, { withFileTypes: true })
+  const posts = []
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const mdxPath = path.join(BLOG_DIR, entry.name, 'en.mdx')
+    if (!fs.existsSync(mdxPath)) continue
+    const content = fs.readFileSync(mdxPath, 'utf-8')
+    const standardSiteUri = readHeaderField(content, 'standardSiteUri')
+    if (!standardSiteUri) continue
+    posts.push({
+      slug: entry.name,
+      mdxPath,
+      content,
+      standardSiteUri,
+      author: readHeaderField(content, 'author'),
+      blueskyPostUrl: readHeaderField(content, 'blueskyPostUrl'),
+    })
+  }
+  return posts
+}
+
+function normalizeBlueskyPostUrlInMdx(content, currentUrl, newUrl) {
+  if (currentUrl === newUrl) return content
+  return content.replace(
+    `blueskyPostUrl: '${currentUrl}'`,
+    `blueskyPostUrl: '${newUrl}'`,
+  )
+}
 
 export async function main(...args) {
   const apply = args.includes('--apply')
@@ -62,6 +96,75 @@ export async function main(...args) {
     }
   }
 
-  // (Walk + compute + apply implemented in Task 9.)
-  console.log('\n(scaffold only; walk implemented in next task)')
+  const posts = listBlogPosts()
+  console.log(`\n🔍 Walking blog MDX files: ${posts.length} with standardSiteUri\n`)
+
+  // Fetch all our documents once and index by URI. publish-post.mjs and
+  // migrate-paths.mjs both use this list-then-match pattern.
+  const { records: docRecords } = await client.list(standard.document.main, {
+    limit: 100,
+  })
+  const byUri = new Map(docRecords.map((r) => [r.uri, r]))
+
+  const plans = []
+  for (const post of posts) {
+    if (!post.author) {
+      throw new Error(`${post.slug}: MDX header missing 'author'`)
+    }
+    const existing = byUri.get(post.standardSiteUri)
+    if (!existing) {
+      throw new Error(
+        `${post.slug}: standardSiteUri ${post.standardSiteUri} not found in PDS records`,
+      )
+    }
+    const contributors = buildContributors(post.author, authors)
+
+    let bskyPostRef = null
+    let normalizedUrl = null
+    if (post.blueskyPostUrl) {
+      bskyPostRef = await resolveBskyPostRef(post.blueskyPostUrl)
+      // bskyPostRef.uri is at://<did>/app.bsky.feed.post/<rkey>; build
+      // the DID-form bsky.app URL from those components.
+      const didMatch = bskyPostRef.uri.match(/^at:\/\/([^/]+)/)
+      const bRkey = bskyPostRef.uri.split('/').pop()
+      if (didMatch && bRkey) {
+        normalizedUrl = `https://bsky.app/profile/${didMatch[1]}/post/${bRkey}`
+      }
+    }
+
+    const rkey = post.standardSiteUri.split('/').pop()
+    const next = {
+      ...existing.value,
+      contributors,
+      ...(bskyPostRef ? { bskyPostRef } : {}),
+      updatedAt: new Date().toISOString(),
+    }
+
+    plans.push({ post, rkey, existing: existing.value, next, normalizedUrl })
+  }
+
+  console.log('\n📋 Planned changes:\n')
+  for (const p of plans) {
+    console.log(`  ${p.post.slug}  (${p.rkey})`)
+    console.log(`    contributors: ${JSON.stringify(p.next.contributors)}`)
+    if (p.next.bskyPostRef) {
+      console.log(`    bskyPostRef:  ${p.next.bskyPostRef.uri}`)
+      console.log(`                  cid=${p.next.bskyPostRef.cid}`)
+    } else {
+      console.log(`    bskyPostRef:  (none — no blueskyPostUrl in MDX)`)
+    }
+    if (p.normalizedUrl && p.normalizedUrl !== p.post.blueskyPostUrl) {
+      console.log(`    MDX URL:      ${p.post.blueskyPostUrl}`)
+      console.log(`              →   ${p.normalizedUrl}`)
+    }
+    console.log('')
+  }
+
+  if (!apply) {
+    console.log('Dry run only. Re-run with --apply to write changes.')
+    return
+  }
+
+  // (Apply branch implemented in Task 10.)
+  console.log('\n(--apply not yet wired; implemented in next task)')
 }

--- a/scripts/migrate-paths.mjs
+++ b/scripts/migrate-paths.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+/**
+ * One-off migration: rewrites site.standard.document records so their
+ * `path` is relative to the publication root (now https://atproto.com/blog)
+ * rather than the site root.
+ *
+ *   before: /blog/<slug>
+ *   after:  /<slug>
+ *
+ * Run --dry-run first (default) to inspect the planned changes, then re-run
+ * with --apply to mutate the records. Each record is updated via client.put
+ * against its existing rkey, preserving the AT-URI referenced by every blog
+ * post's MDX standardSiteUri header.
+ *
+ * Usage:
+ *   npm run blog migrate-paths            # dry run
+ *   npm run blog migrate-paths -- --apply # actually write
+ */
+
+import { Client } from '@atproto/lex'
+import { PasswordSession } from '@atproto/lex-password-session'
+import * as siteModule from '../src/lexicons/site.ts'
+const { standard } = siteModule.default ?? siteModule
+
+const OLD_PREFIX = '/blog/'
+const NEW_PREFIX = '/'
+
+export async function main(...args) {
+  const apply = args.includes('--apply')
+  const mode = apply ? 'APPLY' : 'DRY-RUN'
+
+  const {
+    ATPROTO_HANDLE,
+    ATPROTO_APP_PASSWORD,
+    ATPROTO_PDS_URL,
+    ATPROTO_PUBLICATION_URI,
+  } = process.env
+
+  if (!ATPROTO_HANDLE || !ATPROTO_APP_PASSWORD) {
+    console.error('Error: Missing required environment variables.')
+    console.error('Please set ATPROTO_HANDLE and ATPROTO_APP_PASSWORD in your .env file.')
+    process.exit(1)
+  }
+
+  const service = ATPROTO_PDS_URL || 'https://bsky.social'
+
+  console.log(`\n🔧 Migrate document paths (${mode})\n`)
+  console.log(`  Service: ${service}`)
+  console.log(`  Handle: ${ATPROTO_HANDLE}`)
+  console.log(`  Rewrite: ${OLD_PREFIX}<slug>  →  ${NEW_PREFIX}<slug>`)
+
+  const session = await PasswordSession.create({
+    service,
+    identifier: ATPROTO_HANDLE,
+    password: ATPROTO_APP_PASSWORD,
+    onUpdated: () => {},
+    onDeleted: () => {},
+  })
+
+  const client = new Client(session)
+  console.log(`✓ Authenticated as ${session.handle} (${session.did})`)
+
+  // Guard: refuse to run against the wrong account when the publication URI
+  // pins ownership to a specific DID. Mirrors the safeguard in publish-post.mjs.
+  if (ATPROTO_PUBLICATION_URI) {
+    const expectedDid = ATPROTO_PUBLICATION_URI.match(/^at:\/\/([^/]+)/)?.[1]
+    if (expectedDid && expectedDid !== session.did) {
+      console.error(
+        `\n❌ Refusing to run: authenticated as ${session.handle} (${session.did})`,
+      )
+      console.error(
+        `   but ATPROTO_PUBLICATION_URI is owned by ${expectedDid}.`,
+      )
+      process.exit(1)
+    }
+  }
+
+  console.log('\n🔍 Listing existing site.standard.document records...')
+  const { records } = await client.list(standard.document.main, { limit: 100 })
+  console.log(`  Found ${records.length} record(s)`)
+
+  const toMigrate = []
+  const skipped = []
+
+  for (const record of records) {
+    const path = record.value.path
+    if (typeof path === 'string' && path.startsWith(OLD_PREFIX)) {
+      toMigrate.push(record)
+    } else {
+      skipped.push({ uri: record.uri, path })
+    }
+  }
+
+  console.log(`\n  To migrate: ${toMigrate.length}`)
+  console.log(`  Skipped:    ${skipped.length}`)
+
+  for (const r of skipped) {
+    console.log(`    · ${r.uri} (path: ${JSON.stringify(r.path)})`)
+  }
+
+  if (toMigrate.length === 0) {
+    console.log('\nNothing to do.')
+    return
+  }
+
+  console.log('\n📋 Planned changes:\n')
+  for (const record of toMigrate) {
+    const slug = record.value.path.slice(OLD_PREFIX.length)
+    const newPath = `${NEW_PREFIX}${slug}`
+    console.log(`  ${record.uri}`)
+    console.log(`    ${record.value.path}  →  ${newPath}`)
+  }
+
+  if (!apply) {
+    console.log('\nDry run only. Re-run with --apply to write changes.')
+    return
+  }
+
+  console.log('\n📤 Applying changes...\n')
+  let updated = 0
+  let failed = 0
+  for (const record of toMigrate) {
+    const rkey = record.uri.split('/').pop()
+    const slug = record.value.path.slice(OLD_PREFIX.length)
+    const newPath = `${NEW_PREFIX}${slug}`
+
+    // Preserve all existing fields; only path and updatedAt change.
+    const next = {
+      ...record.value,
+      path: newPath,
+      updatedAt: new Date().toISOString(),
+    }
+
+    try {
+      const result = await client.put(standard.document.main, next, { rkey })
+      console.log(`  ✓ ${result.uri}  path: ${newPath}`)
+      updated++
+    } catch (err) {
+      console.error(`  ✗ ${record.uri}  ${err.message}`)
+      failed++
+    }
+  }
+
+  console.log(`\n✅ Done. Updated ${updated}, failed ${failed}.`)
+  if (failed > 0) process.exit(1)
+}

--- a/scripts/publish-post.mjs
+++ b/scripts/publish-post.mjs
@@ -25,6 +25,9 @@ import { PasswordSession } from '@atproto/lex-password-session'
 import * as acorn from 'acorn'
 import * as siteModule from '../src/lexicons/site.ts'
 const { standard } = siteModule.default ?? siteModule
+import authors from '../src/lib/authors.json' with { type: 'json' }
+import { resolveBskyPostRef } from './lib/resolveBskyPostRef.mjs'
+import { buildContributors } from './lib/buildContributors.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const BLOG_DIR = path.join(__dirname, '../src/app/[locale]/blog')
@@ -217,6 +220,22 @@ export async function main(slug) {
     console.log(`\n⚠️  No ATPROTO_PUBLICATION_URI set, using URL: ${SITE_URL}`)
   }
 
+  // Build contributors from the MDX author. Fail loud if the author
+  // string isn't in authors.json — better than silently emitting a
+  // contributor-less record.
+  if (!header.author) {
+    console.error('\n❌ Missing `author` field in MDX header.')
+    process.exit(1)
+  }
+  const contributors = buildContributors(header.author, authors)
+
+  let bskyPostRef
+  if (header.blueskyPostUrl) {
+    console.log('\n🔗 Resolving bskyPostRef...')
+    bskyPostRef = await resolveBskyPostRef(header.blueskyPostUrl)
+    console.log(`   ${bskyPostRef.uri}`)
+  }
+
   // Check for existing document with same path. Path is relative to the
   // publication's url (https://atproto.com/blog), so it's just /<slug>.
   const postPath = `/${slug}`
@@ -246,6 +265,8 @@ export async function main(slug) {
         path: postPath,
         publishedAt: parseDate(header.date),
         updatedAt: new Date().toISOString(),
+        contributors,
+        ...(bskyPostRef ? { bskyPostRef } : {}),
       },
       { rkey }
     )
@@ -264,6 +285,8 @@ export async function main(slug) {
       description: header.description,
       path: postPath,
       publishedAt: parseDate(header.date),
+      contributors,
+      ...(bskyPostRef ? { bskyPostRef } : {}),
     })
 
     documentUri = result.uri

--- a/src/app/[locale]/blog/2026-spring-roadmap/en.mdx
+++ b/src/app/[locale]/blog/2026-spring-roadmap/en.mdx
@@ -4,7 +4,7 @@ export const header = {
   description: 'Updates to the AT Protocol roadmap, including Permissioned Data and Account Experience.',
   date: 'March 24, 2026',
   author: 'Bluesky Protocol Team',
-  blueskyPostUrl: 'https://bsky.app/profile/atproto.com/post/3mhtaxg4ppk2v'
+  blueskyPostUrl: 'https://bsky.app/profile/did:plc:ewvi7nxzyoun6zhxrhs64oiz/post/3mhtaxg4ppk2v'
 }
 
 # AT Protocol Roadmap (Spring 2026\)

--- a/src/app/[locale]/blog/indexing-standard-site/en.mdx
+++ b/src/app/[locale]/blog/indexing-standard-site/en.mdx
@@ -4,7 +4,7 @@ export const header = {
   description: 'This guest post from Steve Simkins, creator of Sequoia and docs.surf, outlines the strategy he used to index standard.site records.',
   date: 'April 14, 2026',
   author: 'Steve Simkins',
-  blueskyPostUrl: 'https://bsky.app/profile/atproto.com/post/3mjigczpd422n'
+  blueskyPostUrl: 'https://bsky.app/profile/did:plc:ewvi7nxzyoun6zhxrhs64oiz/post/3mjigczpd422n'
 }
 
 *We’re excited to publish another guest post highlighting development in the atproto ecosystem. Steve Simkins is one of the more prolific developers building on the Standard Site lexicon, as the builder behind the [Sequoia CLI tool](https://sequoia.pub/) and the delightful [docs.surf](https://docs.surf) reader app. In this post, Steve lays out his approach to indexing standard.site records in a way that is both efficient and cost effective. Be sure to check out Steve’s [original post](https://stevedylan.dev/posts/indexing-standard-site/) on his personal blog, complete with zoomable diagrams, and [standard.site records](https://pdsls.dev/at://did:plc:ia2zdnhjaokf5lazhxrmj6eu/site.standard.document), of course.*

--- a/src/app/[locale]/blog/kicking-off-the-atp-working-group/en.mdx
+++ b/src/app/[locale]/blog/kicking-off-the-atp-working-group/en.mdx
@@ -4,7 +4,7 @@ export const header = {
   description: 'The Authenticated Transfer Protocol (ATP) working group has been created at the IETF, and we are seeking participation from the broader Atmosphere ecosystem.',
   date: 'April 2, 2026',
   author: 'AT Protocol Team',
-  blueskyPostUrl: 'https://bsky.app/profile/atproto.com/post/3mik6af7p4k22'
+  blueskyPostUrl: 'https://bsky.app/profile/did:plc:ewvi7nxzyoun6zhxrhs64oiz/post/3mik6af7p4k22'
 }
 
 We are pleased to announce that an [Authenticated Transfer Protocol (ATP) working group](https://datatracker.ietf.org/wg/atp/about/) has been created at the IETF\!

--- a/src/app/[locale]/blog/plc-replicas/en.mdx
+++ b/src/app/[locale]/blog/plc-replicas/en.mdx
@@ -4,7 +4,7 @@ export const header = {
   description: 'Introducing a self-hostable did:plc read-replica service.',
   date: 'February 18, 2026',
   author: 'David Buchanan',
-  blueskyPostUrl: 'https://bsky.app/profile/atproto.com/post/3mf5pgwprik2b'
+  blueskyPostUrl: 'https://bsky.app/profile/did:plc:ewvi7nxzyoun6zhxrhs64oiz/post/3mf5pgwprik2b'
 }
 
 # PLC Read Replicas

--- a/src/app/[locale]/blog/report-based-moderation/en.mdx
+++ b/src/app/[locale]/blog/report-based-moderation/en.mdx
@@ -10,7 +10,7 @@ export const header = {
   description: 'A report-centric workflow for Ozone with new queues, assignments, real-time collaboration, and a per-report activity log.',
   date: 'May 11, 2026',
   author: 'AT Protocol Team',
-  blueskyPostUrl: 'https://bsky.app/profile/atproto.com/post/3mlloo2ibwk2y'
+  blueskyPostUrl: 'https://bsky.app/profile/did:plc:ewvi7nxzyoun6zhxrhs64oiz/post/3mlloo2ibwk2y'
 }
 
 ## Improving Ozone

--- a/src/app/[locale]/blog/ts-sdk-upgrades/en.mdx
+++ b/src/app/[locale]/blog/ts-sdk-upgrades/en.mdx
@@ -4,7 +4,7 @@ export const header = {
   description: 'Modernizing our TS packages and moving the lex SDK closer to 1.0',
   date: 'May 21, 2026',
   author: 'AT Protocol Team',
-  blueskyPostUrl: 'https://bsky.app/profile/atproto.com/post/3mmf72xkixc23'
+  blueskyPostUrl: 'https://bsky.app/profile/did:plc:ewvi7nxzyoun6zhxrhs64oiz/post/3mmf72xkixc23'
 }
 
 ## SDK Modernization

--- a/src/app/[locale]/providers.tsx
+++ b/src/app/[locale]/providers.tsx
@@ -5,6 +5,18 @@ import { ThemeProvider, useTheme } from 'next-themes'
 import { usePathname } from 'next/navigation'
 import { stripLocalePrefix } from '@/components/Navigation'
 
+// Next.js App Router skips its scroll-to-top reset when sibling pages share a
+// layout and the new segment's element is judged "already visible" — most
+// noticeable on /blog → /blog/<slug>, where users land on the post still
+// scrolled down. Force a reset on every pathname change.
+function ScrollToTop() {
+  const pathname = usePathname()
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [pathname])
+  return null
+}
+
 function ThemeWatcher() {
   let { resolvedTheme, setTheme } = useTheme()
 
@@ -40,6 +52,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
       forcedTheme={isHome ? 'dark' : undefined}
     >
       <ThemeWatcher />
+      <ScrollToTop />
       {children}
     </ThemeProvider>
   )

--- a/src/lib/authors.json
+++ b/src/lib/authors.json
@@ -15,5 +15,7 @@
   "Zeu": "did:plc:gotnvwkr56ibs33l4hwgfoet",
   "Boris Mann": "did:plc:2cxgdrgtsmrbqnjkwyplmp43",
   "Ted Han": "did:plc:l5yz32nydpebjlcdfgycmf3x",
-  "Rishi Balakrishnan": "did:plc:y3dbemzlq5lzfl7osurqzi2c"
+  "Rishi Balakrishnan": "did:plc:y3dbemzlq5lzfl7osurqzi2c",
+  "Bluesky Protocol Team": "did:plc:ewvi7nxzyoun6zhxrhs64oiz",
+  "AT Protocol Team": "did:plc:ewvi7nxzyoun6zhxrhs64oiz"
 }


### PR DESCRIPTION
- **Sync site.standard.document lexicon for contributors**
- **Map team author names to atproto.com DID**
- **Add failing tests for parseBskyUrl**
- **Implement parseBskyUrl**
- **Add failing tests for buildContributors**
- **Implement buildContributors**
- **Implement resolveBskyPostRef helper**
- **Scaffold migrate-contributors-and-refs script + dispatcher entry**
- **Compute migration plans for contributors/bskyPostRef (dry-run)**
- **Wire --apply branch for contributors/bskyPostRef migration**
- **Emit contributors + bskyPostRef when publishing posts**
- **Harden MDX rewrite and stamp updatedAt at write time**
- **Updated blog posts with new standard site contributor features**
