### PR TITLE
Fix production 500s on code-block pages (React.Children.only vs RSC streaming)

### DIFF
--- a/src/components/Code.tsx
+++ b/src/components/Code.tsx
@@ -142,9 +142,10 @@ function CodePanel({
   label?: string
   code?: string
 }) {
-  let child = Children.only(children)
+  let child =
+    Array.isArray(children) && children.length === 1 ? children[0] : children
 
-  if (isValidElement(child)) {
+  if (isValidElement<{ tag?: string; label?: string; code?: string }>(child)) {
     tag = child.props.tag ?? tag
     label = child.props.label ?? label
     code = child.props.code ?? code


### PR DESCRIPTION
## Problem

22 page/locale combinations currently return **HTTP 500 on atproto.com** (production only — not reproducible in `next dev`). All of them are pages containing code blocks, e.g.:

- https://atproto.com/en/guides/statusphere-tutorial (all 4 locales)
- https://atproto.com/en/guides/installing-lexicons (all 4 locales)
- https://atproto.com/en/blog/create-post (all 4 locales)
- https://atproto.com/en/guides/identity (en, pt)
- https://atproto.com/en/guides/feeds (en, pt)
- https://atproto.com/en/guides/bot-tutorial (en)
- https://atproto.com/ja/guides/lexicon (ja, ko)
- https://atproto.com/ko/specs/tid, https://atproto.com/ko/specs/permission, https://atproto.com/ko/guides/streaming-data (ko)

Server logs show:

```
⨯ Error: React.Children.only expected to receive a single React element child.
    at x (.next/server/chunks/4675.js:1:3402) { digest: '2513824698' }
```

## Root cause

`CodePanel` in `src/components/Code.tsx` (a client component) calls `React.Children.only(children)` on children that cross the server→client boundary (MDX `pre` elements are created in RSC). With RSC streaming in production builds, when the child element happens to fall across a flight payload chunk boundary, it is delivered as a **lazy reference instead of a plain element**. Injecting logging into the built chunk at the throw site confirms it:

```
children: Symbol(react.lazy) { $$typeof, _payload, _init }
```

`Children.only` rejects lazy references, so the page throws during render. Whether a given page fails depends on byte offsets in the payload (content length per locale, number/size of code blocks), which is why the failing set looks random across pages and locales. Dev resolves the payload eagerly, so it never reproduces there — these pages render fine in `next dev`.

## Fix

Replace `Children.only` with a tolerant unwrap, and only sniff `tag`/`label`/`code` props off the child when it is a real element. Markdown code fences are unaffected: the `rehypeShiki` plugin already sets `code`/`language` directly as props on the `pre` element, so nothing is lost when the child arrives lazy.

## Verification

Crawled all 122 routes × 4 locales (488 URLs) against a local production build (`next build` + `next start`):

- **Before:** 22 URLs return 500 — exactly matching the set currently failing on atproto.com
- **After:** all 488 URLs return 200, no errors in server logs; syntax highlighting and the copy button render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)