### PR TITLE
RSS fixes

### DIFF
--- a/scripts/new-episode.mjs
+++ b/scripts/new-episode.mjs
@@ -259,6 +259,7 @@ export default async function EpisodeRoute({ params }: any) {
   description: '${description.replace(/'/g, "\\'")}',
   date: '${date}',
   pubDate: '${pubDate}',
+  hosts: ['Jim Ray'],
   duration: '${duration}',
   durationSeconds: ${durationSeconds},
 ${guestsField}  audioUrl: '${audioUrl.replace(/'/g, "\\'")}',
@@ -290,11 +291,10 @@ ${blueskyField}}
     pubDate: '${pubDate}',
     duration: '${duration}',
     durationSeconds: ${durationSeconds},
+    hosts: ['Jim Ray'],
 ${guests.length ? `    guests: [${guests.map((g) => `'${g.replace(/'/g, "\\'")}'`).join(', ')}],\n` : ''}    audioUrl: '${audioUrl.replace(/'/g, "\\'")}',
     audioSizeBytes: ${audioInfo.sizeBytes},
     audioMimeType: '${audioInfo.contentType.replace(/'/g, "\\'")}',
-    hasShowNotes: false,
-    hasTranscript: false,
 ${blueskyPostUrl ? `    blueskyPostUrl: '${blueskyPostUrl.replace(/'/g, "\\'")}',\n` : ''}  },`
 
   const updated = episodesFile.replace(
@@ -325,8 +325,8 @@ Files:
 
 Next:
   1. Edit en.mdx with your show notes, then flip hasShowNotes: true
-     (in both the MDX header and src/lib/episodes.ts)
-  2. Edit transcript.mdx, then flip hasTranscript: true (same two places)
+     in the MDX header (the single source of truth — the RSS feed reads it)
+  2. Edit transcript.mdx, then flip hasTranscript: true in the MDX header
   3. npm run dev — preview at http://localhost:3000/off-protocol/${slug}
 `)
 }

--- a/src/app/[locale]/off-protocol/a-thousand-prs-in-two-weeks-building-npmx/en.mdx
+++ b/src/app/[locale]/off-protocol/a-thousand-prs-in-two-weeks-building-npmx/en.mdx
@@ -7,7 +7,7 @@ export const header = {
   pubDate: '2026-02-27T12:00:00Z',
   duration: '00:58:45',
   durationSeconds: 3525,
-  host: ['Jim Ray', 'Alex Garnett'],
+  hosts: ['Jim Ray', 'Alex Garnett'],
   guests: ['Daniel Roe', 'Matias Capeletto', 'Zeu'],
   audioUrl: 'https://media.atproto.com/off-protocol/20260227-live/2026-02-27-npmx-team.mp3',
   audioSizeBytes: 112814592,

--- a/src/app/[locale]/off-protocol/blacksky-as-a-service-a-first-look-at-acorn/en.mdx
+++ b/src/app/[locale]/off-protocol/blacksky-as-a-service-a-first-look-at-acorn/en.mdx
@@ -7,7 +7,7 @@ export const header = {
   pubDate: '2026-04-24T12:00:00Z',
   duration: '00:55:55',
   durationSeconds: 3355,
-  host: ['Jim Ray', 'Alex Garnett'],
+  hosts: ['Jim Ray', 'Alex Garnett'],
   guests: ['Rishi Balakrishnan'],
   audioUrl: 'https://media.atproto.com/off-protocol/20260424-live/2026-04-24-live-rishi-acorn.mp3',
   audioSizeBytes: 107389440,

--- a/src/app/[locale]/off-protocol/cobblers-kids/en.mdx
+++ b/src/app/[locale]/off-protocol/cobblers-kids/en.mdx
@@ -4,7 +4,7 @@ export const header = {
   description: 'Jim and Alex are back on the livestream at a new time to discuss personal websites, Coop 1.0, exciting announcements from Eurosky, a new OAuth scope builder, and more news from the Atmosphere.',
   date: 'June 15, 2026',
   pubDate: '2026-06-15T21:24:51.805Z',
-  host: ['Jim Ray', 'Alex Garnett'],
+  hosts: ['Jim Ray', 'Alex Garnett'],
   duration: '00:40:20',
   durationSeconds: 2419,
   audioUrl: 'https://media.atproto.com/off-protocol/2026-06-10-live/2026-06-10-live-jim-alex.mp3',

--- a/src/app/[locale]/off-protocol/in-our-timeline/en.mdx
+++ b/src/app/[locale]/off-protocol/in-our-timeline/en.mdx
@@ -4,7 +4,7 @@ export const header = {
   description: 'Paul and Daniel are on the livestream this week with a look at the new Standard.site integration, updates from permissioned data, and news from around the Atmosphere',
   date: 'May 29, 2026',
   pubDate: '2026-06-11T20:00:18.291Z',
-  host: ['Paul Frazee', 'Daniel Holmgren'],
+  hosts: ['Paul Frazee', 'Daniel Holmgren'],
   duration: '00:46:29',
   durationSeconds: 2789,
   audioUrl: 'https://media.atproto.com/off-protocol/2026-05-29-live/2026-05-29-live-paul-daniel.mp3',

--- a/src/app/[locale]/off-protocol/the-puppy-problem/en.mdx
+++ b/src/app/[locale]/off-protocol/the-puppy-problem/en.mdx
@@ -7,7 +7,7 @@ export const header = {
   pubDate: '2026-05-15T12:00:00Z',
   duration: '00:33:08',
   durationSeconds: 1988,
-  host: ['Jim Ray', 'Alex Garnett'],
+  hosts: ['Jim Ray', 'Alex Garnett'],
   audioUrl: 'https://media.atproto.com/off-protocol/20260515-live/2026-05-15-off-protocol-live.mp3',
   audioSizeBytes: 63624960,
   audioMimeType: 'audio/mpeg',

--- a/src/app/off-protocol/rss.xml/route.ts
+++ b/src/app/off-protocol/rss.xml/route.ts
@@ -11,13 +11,14 @@ import { episodes, SHOW, type Episode } from '@/lib/episodes'
 import { buildPodcastFeed, type FeedEpisode } from '@/lib/podcast-feed'
 import {
   mdxBodyToHtml,
+  readShowNotesFlag,
   stripMdxFrontmatter,
 } from '@/lib/podcast-feed-content'
 
-async function loadEpisodeContentHtml(slug: string): Promise<string> {
-  // Show notes live alongside the episode pages under [locale]; we always
-  // read the English MDX for the (English-only) feed.
-  const mdxPath = path.join(
+// Show notes live alongside the episode pages under [locale]; we always read
+// the English MDX for the (English-only) feed.
+function episodeMdxPath(slug: string): string {
+  return path.join(
     process.cwd(),
     'src',
     'app',
@@ -26,13 +27,6 @@ async function loadEpisodeContentHtml(slug: string): Promise<string> {
     slug,
     'en.mdx',
   )
-  try {
-    const raw = await fs.readFile(mdxPath, 'utf-8')
-    const body = stripMdxFrontmatter(raw)
-    return await mdxBodyToHtml(body)
-  } catch {
-    return '<p></p>'
-  }
 }
 
 function xmlEscape(s: string): string {
@@ -44,13 +38,27 @@ function xmlEscape(s: string): string {
     .replace(/'/g, '&apos;')
 }
 
-async function resolveContentHtml(episode: Episode): Promise<string> {
-  // When the author hasn't published real show notes yet, fall back to the
-  // episode description so podcatchers still have meaningful copy.
-  if (!episode.hasShowNotes) {
-    return `<p>${xmlEscape(episode.description)}</p>`
+// The MDX header is the single source of truth for whether real show notes
+// exist; derive both the flag and the rendered notes from that one file so the
+// feed and the episode page can never disagree. <content:encoded> gets the
+// notes when present, otherwise the episode summary as a fallback.
+async function resolveFeedFields(
+  episode: Episode,
+): Promise<{ hasShowNotes: boolean; contentHtml: string }> {
+  const summaryHtml = `<p>${xmlEscape(episode.description)}</p>`
+  let raw: string
+  try {
+    raw = await fs.readFile(episodeMdxPath(episode.slug), 'utf-8')
+  } catch {
+    return { hasShowNotes: false, contentHtml: summaryHtml }
   }
-  return loadEpisodeContentHtml(episode.slug)
+  if (!readShowNotesFlag(raw)) {
+    return { hasShowNotes: false, contentHtml: summaryHtml }
+  }
+  return {
+    hasShowNotes: true,
+    contentHtml: await mdxBodyToHtml(stripMdxFrontmatter(raw)),
+  }
 }
 
 // Behind a reverse proxy (Render, Cloudflare Pages, Vercel, etc.), the
@@ -77,7 +85,7 @@ export async function GET(request: Request) {
   const feedEpisodes: FeedEpisode[] = await Promise.all(
     episodes.map(async (e) => ({
       ...e,
-      contentHtml: await resolveContentHtml(e),
+      ...(await resolveFeedFields(e)),
     })),
   )
 

--- a/src/components/EpisodeHeader.tsx
+++ b/src/components/EpisodeHeader.tsx
@@ -1,7 +1,7 @@
 import { Fragment } from 'react'
 import Link from 'next/link'
 import knownAuthors from '@/lib/authors.json'
-import { SHOW, type Episode } from '@/lib/episodes'
+import { resolveHosts, type Episode } from '@/lib/episodes'
 import { SubscribeLinks } from './SubscribeLinks'
 
 // Renders a name as a link to bsky.app when authors.json knows its DID,
@@ -60,13 +60,13 @@ export interface EpisodeHeaderProps
     | 'date'
     | 'pubDate'
     | 'guests'
-    | 'host'
+    | 'hosts'
     | 'audioUrl'
     | 'audioMimeType'
   > {}
 
 export function EpisodeHeader(props: EpisodeHeaderProps) {
-  const hosts = props.host ?? [SHOW.defaultHost]
+  const hosts = resolveHosts(props)
   const mimeType = props.audioMimeType ?? 'audio/mpeg'
 
   return (

--- a/src/components/EpisodePage.tsx
+++ b/src/components/EpisodePage.tsx
@@ -14,10 +14,16 @@ interface EpisodePageProps {
   default: MDXContent
   /**
    * Header data — same fields as Episode, minus the slug-level concerns.
-   * Comes from the MDX module's `header` export.
+   * Comes from the MDX module's `header` export. `hasShowNotes` /
+   * `hasTranscript` live only in the MDX header (the single source of truth
+   * for whether real notes/transcript content exists), not in the Episode
+   * catalog, so they're declared here directly.
    */
   header: EpisodeHeaderProps &
-    Pick<Episode, 'blueskyPostUrl' | 'hasShowNotes' | 'hasTranscript'>
+    Pick<Episode, 'blueskyPostUrl'> & {
+      hasShowNotes?: boolean
+      hasTranscript?: boolean
+    }
   /** Optional default export of a transcript MDX module. */
   Transcript?: MDXContent
 }

--- a/src/lib/episodes.test.ts
+++ b/src/lib/episodes.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { resolveHosts, SHOW } from './episodes'
+
+describe('resolveHosts', () => {
+  it('returns the episode hosts when they are set', () => {
+    expect(resolveHosts({ hosts: ['Paul Frazee', 'Daniel Holmgren'] })).toEqual(
+      ['Paul Frazee', 'Daniel Holmgren'],
+    )
+  })
+
+  it("defaults to ['Jim Ray'] when hosts is omitted", () => {
+    expect(resolveHosts({})).toEqual(['Jim Ray'])
+  })
+
+  it('uses the show default host for the fallback', () => {
+    expect(SHOW.defaultHost).toBe('Jim Ray')
+    expect(resolveHosts({})).toEqual([SHOW.defaultHost])
+  })
+})

--- a/src/lib/episodes.ts
+++ b/src/lib/episodes.ts
@@ -23,13 +23,11 @@ export interface Episode {
   duration: string              // "HH:MM:SS" — RSS spec format
   durationSeconds: number       // numeric, easier to format/sort
   guests?: string[]
-  host?: string[]               // defaults to [SHOW.defaultHost] when omitted
+  hosts?: string[]              // defaults to [SHOW.defaultHost] when omitted
   audioUrl: string              // absolute CDN URL to the MP3
   audioSizeBytes: number        // required by RSS <enclosure length="…">
   audioMimeType?: string        // defaults to "audio/mpeg"
   coverImage?: string           // square, ≥1400px; falls back to SHOW.coverImage
-  hasShowNotes?: boolean        // author flips to true when en.mdx body has real content
-  hasTranscript?: boolean       // author flips to true when transcript.mdx has real content
   explicit?: boolean            // RSS <itunes:explicit>; defaults false
   blueskyPostUrl?: string       // optional Bluesky discussion thread anchor
 }
@@ -46,6 +44,16 @@ export function formatDurationForDisplay(seconds: number): string {
   const s = seconds % 60
   const pad = (n: number) => n.toString().padStart(2, '0')
   return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`
+}
+
+/**
+ * The hosts to display for an episode: the episode's own `hosts` when set,
+ * otherwise the show default ([SHOW.defaultHost], i.e. ['Jim Ray']). Codifies
+ * the host fallback in one place so the page header and any other consumer
+ * agree.
+ */
+export function resolveHosts(episode: Pick<Episode, 'hosts'>): string[] {
+  return episode.hosts ?? [SHOW.defaultHost]
 }
 
 export interface SubscribeUrls {
@@ -100,8 +108,6 @@ export const episodes: Episode[] = [
     audioUrl: 'https://media.atproto.com/off-protocol/2026-06-10-live/2026-06-10-live-jim-alex.mp3',
     audioSizeBytes: 19470143,
     audioMimeType: 'audio/mpeg',
-    hasShowNotes: false,
-    hasTranscript: false,
   },
   {
     slug: 'in-our-timeline',
@@ -110,14 +116,12 @@ export const episodes: Episode[] = [
     description: 'Paul and Daniel are on the livestream this week with a look at the new Standard.site integration, updates from permissioned data, and news from around the Atmosphere',
     date: 'May 29, 2026',
     pubDate: '2026-06-11T20:00:18.291Z',
-    host: ['Paul Frazee', 'Daniel Holmgren'],
+    hosts: ['Paul Frazee', 'Daniel Holmgren'],
     duration: '00:46:29',
     durationSeconds: 2789,
     audioUrl: 'https://media.atproto.com/off-protocol/2026-05-29-live/2026-05-29-live-paul-daniel.mp3',
     audioSizeBytes: 22320651,
     audioMimeType: 'audio/mpeg',
-    hasShowNotes: false,
-    hasTranscript: false,
   },
   {
     slug: 'do-this-together-standard-site',
@@ -132,8 +136,6 @@ export const episodes: Episode[] = [
     audioUrl: 'https://media.atproto.com/off-protocol/20260528-conversation-standard-site/2026-05-28-conversation-standard-site.mp3',
     audioSizeBytes: 123247872,
     audioMimeType: 'audio/mpeg',
-    hasShowNotes: false,
-    hasTranscript: false,
   },
   {
     slug: 'the-puppy-problem',
@@ -145,12 +147,10 @@ export const episodes: Episode[] = [
     pubDate: '2026-05-15T12:00:00Z',
     duration: '00:33:08',
     durationSeconds: 1988,
-    host: ['Jim Ray', 'Alex Garnett'],
+    hosts: ['Jim Ray', 'Alex Garnett'],
     audioUrl: 'https://media.atproto.com/off-protocol/20260515-live/2026-05-15-off-protocol-live.mp3',
     audioSizeBytes: 63624960,
     audioMimeType: 'audio/mpeg',
-    hasShowNotes: false,
-    hasTranscript: false,
   },
   {
     slug: 'why-a-new-protocol-the-history-and-future-of-at-protocol',
@@ -166,8 +166,6 @@ export const episodes: Episode[] = [
     audioUrl: 'https://media.atproto.com/off-protocol/20260524-conversation/2026-05-14-conversation-paul-danny.mp3',
     audioSizeBytes: 114122496,
     audioMimeType: 'audio/mpeg',
-    hasShowNotes: false,
-    hasTranscript: false,
   },
   {
     slug: 'blacksky-as-a-service-a-first-look-at-acorn',
@@ -179,13 +177,11 @@ export const episodes: Episode[] = [
     pubDate: '2026-04-24T12:00:00Z',
     duration: '00:55:55',
     durationSeconds: 3355,
-    host: ['Jim Ray', 'Alex Garnett'],
+    hosts: ['Jim Ray', 'Alex Garnett'],
     guests: ['Rishi Balakrishnan'],
     audioUrl: 'https://media.atproto.com/off-protocol/20260424-live/2026-04-24-live-rishi-acorn.mp3',
     audioSizeBytes: 107389440,
     audioMimeType: 'audio/mpeg',
-    hasShowNotes: true,
-    hasTranscript: false,
   },
   {
     slug: 'slowly-then-quickly-what-atmosphereconf-made-visible',
@@ -201,8 +197,6 @@ export const episodes: Episode[] = [
     audioUrl: 'https://media.atproto.com/off-protocol/20260410-live/2026-04-10-live-boris-ted.mp3',
     audioSizeBytes: 127011840,
     audioMimeType: 'audio/mpeg',
-    hasShowNotes: true,
-    hasTranscript: false,
   },
   {
     slug: 'a-thousand-prs-in-two-weeks-building-npmx',
@@ -214,13 +208,11 @@ export const episodes: Episode[] = [
     pubDate: '2026-02-27T12:00:00Z',
     duration: '00:58:45',
     durationSeconds: 3525,
-    host: ['Jim Ray', 'Alex Garnett'],
+    hosts: ['Jim Ray', 'Alex Garnett'],
     guests: ['Daniel Roe', 'Matias Capeletto', 'Zeu'],
     audioUrl: 'https://media.atproto.com/off-protocol/20260227-live/2026-02-27-npmx-team.mp3',
     audioSizeBytes: 112814592,
     audioMimeType: 'audio/mpeg',
-    hasShowNotes: true,
-    hasTranscript: false,
   },
   // newest first; populate via `npm run podcast create`
 ]

--- a/src/lib/podcast-feed-content.test.ts
+++ b/src/lib/podcast-feed-content.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import { readShowNotesFlag } from './podcast-feed-content'
+
+const header = (body: string) => `export const header = {
+  episodeNumber: 1,
+  title: 'X',
+${body}
+}
+
+Show notes body.`
+
+describe('readShowNotesFlag', () => {
+  it('is true when the MDX header sets hasShowNotes: true', () => {
+    expect(readShowNotesFlag(header('  hasShowNotes: true,'))).toBe(true)
+  })
+
+  it('is false when the MDX header sets hasShowNotes: false', () => {
+    expect(readShowNotesFlag(header('  hasShowNotes: false,'))).toBe(false)
+  })
+
+  it('is false when the header omits the flag', () => {
+    expect(readShowNotesFlag(header("  date: 'May 1, 2026',"))).toBe(false)
+  })
+
+  it('reads the header, not matching text in the notes body', () => {
+    const mdx = `export const header = {
+  hasShowNotes: false,
+}
+
+In this episode we discuss hasShowNotes: true and how feeds work.`
+    expect(readShowNotesFlag(mdx)).toBe(false)
+  })
+})

--- a/src/lib/podcast-feed-content.ts
+++ b/src/lib/podcast-feed-content.ts
@@ -34,6 +34,23 @@ export async function mdxBodyToHtml(rawMdxBody: string): Promise<string> {
  * The blog/podcast convention places the header at the very top, so this
  * is sufficient. We do NOT try to be a general MDX parser.
  */
+/**
+ * Read `hasShowNotes` from an episode MDX file's `export const header` block.
+ * The MDX header is the single source of truth for whether real show notes
+ * have been written (the author flips it on alongside the notes); the RSS feed
+ * derives note presence from here rather than from a duplicated flag.
+ *
+ * Scoped to the header block so a mention like "hasShowNotes: true" in the
+ * notes prose can't flip it on.
+ */
+export function readShowNotesFlag(rawMdx: string): boolean {
+  const headerMatch = rawMdx.match(
+    /export\s+const\s+header\s*=\s*\{[\s\S]*?\n\}/,
+  )
+  const headerScope = headerMatch ? headerMatch[0] : ''
+  return /\bhasShowNotes:\s*true\b/.test(headerScope)
+}
+
 export function stripMdxFrontmatter(rawMdx: string): string {
   let out = rawMdx
 

--- a/src/lib/podcast-feed.test.ts
+++ b/src/lib/podcast-feed.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { buildPodcastFeed, type FeedEpisode } from './podcast-feed'
+import type { ShowMeta } from './episodes'
+
+const show: ShowMeta = {
+  title: 'Off Protocol',
+  description: 'Show description.',
+  author: 'Bluesky DevRel',
+  defaultHost: 'Jim Ray',
+  ownerEmail: 'hello@example.com',
+  language: 'en-US',
+  category: 'Technology',
+  coverImage: 'https://media.example.com/cover.png',
+  feedUrl: 'https://example.com/off-protocol/rss.xml',
+  siteUrl: 'https://example.com/off-protocol',
+  subscribe: { apple: null, spotify: null },
+}
+
+function makeEpisode(overrides: Partial<FeedEpisode> = {}): FeedEpisode {
+  return {
+    slug: 'my-slug',
+    episodeNumber: 1,
+    title: 'My Episode',
+    description: 'A one sentence summary.',
+    date: 'May 1, 2026',
+    pubDate: '2026-05-01T12:00:00Z',
+    duration: '00:10:00',
+    durationSeconds: 600,
+    audioUrl: 'https://media.example.com/ep.mp3',
+    audioSizeBytes: 12345,
+    audioMimeType: 'audio/mpeg',
+    hasShowNotes: false,
+    contentHtml: '<p>A one sentence summary.</p>',
+    ...overrides,
+  }
+}
+
+// Pull the single <item> block out of a feed so channel-level elements
+// (which share tag names like <description>) don't interfere.
+function itemBlock(xml: string): string {
+  const m = xml.match(/<item>[\s\S]*<\/item>/)
+  if (!m) throw new Error('no <item> found in feed')
+  return m[0]
+}
+
+// The item <description> is a plain (XML-escaped) summary, not CDATA.
+function descriptionOf(block: string): string | null {
+  const m = block.match(/<description>([\s\S]*?)<\/description>/)
+  return m ? m[1] : null
+}
+
+// Read the CDATA payload of a given element inside a block.
+function cdataOf(block: string, tag: string): string | null {
+  const m = block.match(
+    new RegExp(`<${tag}><!\\[CDATA\\[([\\s\\S]*?)\\]\\]></${tag}>`),
+  )
+  return m ? m[1] : null
+}
+
+const PAGE_HREF = 'href="https://example.com/off-protocol/my-slug"'
+
+describe('buildPodcastFeed — item <description>', () => {
+  it('is the episode summary, never the show notes', () => {
+    const xml = buildPodcastFeed(show, [
+      makeEpisode({
+        hasShowNotes: true,
+        description: 'A one sentence summary.',
+        contentHtml: '<h2>Links</h2><p>The full show notes.</p>',
+      }),
+    ])
+    const desc = descriptionOf(itemBlock(xml))
+    expect(desc).toContain('A one sentence summary.')
+    expect(desc).not.toContain('<h2>Links</h2>')
+    expect(desc).not.toContain('The full show notes.')
+  })
+
+  it('does not carry the link-back', () => {
+    const xml = buildPodcastFeed(show, [makeEpisode({ hasShowNotes: true })])
+    expect(descriptionOf(itemBlock(xml))).not.toContain(PAGE_HREF)
+  })
+})
+
+describe('buildPodcastFeed — <content:encoded>', () => {
+  it('contains the full show notes when the episode has them', () => {
+    const xml = buildPodcastFeed(show, [
+      makeEpisode({
+        hasShowNotes: true,
+        contentHtml: '<h2>Links</h2><p>The full show notes.</p>',
+      }),
+    ])
+    const content = cdataOf(itemBlock(xml), 'content:encoded')
+    expect(content).toContain('<h2>Links</h2>')
+    expect(content).toContain('The full show notes.')
+  })
+
+  it('appends the link-back to the episode page', () => {
+    const xml = buildPodcastFeed(show, [makeEpisode({ hasShowNotes: true })])
+    const content = cdataOf(itemBlock(xml), 'content:encoded')
+    expect(content).toContain(PAGE_HREF)
+  })
+})

--- a/src/lib/podcast-feed.ts
+++ b/src/lib/podcast-feed.ts
@@ -17,6 +17,8 @@ import type { Episode, ShowMeta } from './episodes'
 export interface FeedEpisode extends Episode {
   /** HTML-rendered show notes; placed in <content:encoded> CDATA. */
   contentHtml: string
+  /** Whether real show notes exist, derived from the episode MDX header. */
+  hasShowNotes: boolean
 }
 
 const ITUNES_NS = 'http://www.itunes.com/dtds/podcast-1.0.dtd'
@@ -61,6 +63,14 @@ function episodeUrl(show: ShowMeta, episode: Episode): string {
   return `${show.siteUrl}/${episode.slug}`
 }
 
+// A visible "go to the web page" link appended to the notes body. The <link>
+// element is the machine-readable permalink; this is the human-clickable one
+// that surfaces inside the rendered notes in every podcatcher.
+function linkBackHtml(pageUrl: string): string {
+  const display = pageUrl.replace(/^https?:\/\//, '')
+  return `<p><a href="${pageUrl}">Listen and read more at ${display}</a></p>`
+}
+
 // Resolve a possibly-relative URL against the show's origin. Absolute URLs
 // (e.g., R2-hosted cover art) pass through unchanged; relative paths get
 // prefixed. Important because cover URLs can be either form.
@@ -78,10 +88,14 @@ function renderItem(ctx: RenderCtx, episode: FeedEpisode): string {
   const { show, origin } = ctx
   const mime = episode.audioMimeType ?? 'audio/mpeg'
   const cover = absUrl(origin, episode.coverImage ?? show.coverImage)
+  const pageUrl = episodeUrl(show, episode)
+  const linkBack = linkBackHtml(pageUrl)
 
+  // <description> is the short episode summary (plain text). The full show
+  // notes — and the link-back — live in <content:encoded> below.
   return `    <item>
       <title>${xmlEscape(episode.title)}</title>
-      <link>${xmlEscape(episodeUrl(show, episode))}</link>
+      <link>${xmlEscape(pageUrl)}</link>
       <description>${xmlEscape(episode.description)}</description>
       <enclosure url="${xmlEscape(episode.audioUrl)}" length="${episode.audioSizeBytes}" type="${xmlEscape(mime)}"/>
       <guid isPermaLink="false">${xmlEscape(episodeGuid(episode))}</guid>
@@ -91,7 +105,7 @@ function renderItem(ctx: RenderCtx, episode: FeedEpisode): string {
       <itunes:episodeType>full</itunes:episodeType>
       <itunes:explicit>${episode.explicit ? 'true' : 'false'}</itunes:explicit>
       <itunes:image href="${xmlEscape(cover)}"/>
-      <content:encoded><![CDATA[${cdataSafe(episode.contentHtml)}]]></content:encoded>
+      <content:encoded><![CDATA[${cdataSafe(episode.contentHtml + linkBack)}]]></content:encoded>
     </item>`
 }
 


### PR DESCRIPTION
RSS feed:
- <description> now carries the episode summary; the full show notes
  (links and resources) go in <content:encoded>, followed by a "Listen
  and read more" link back to the episode page.
- Derive hasShowNotes from the MDX header (the same source the episode
  page uses) instead of a duplicated flag in episodes.ts. That flag had
  drifted stale and was hiding notes for recent episodes. Removed the
  now-redundant hasShowNotes/hasTranscript from the Episode catalog;
  the MDX header is the single source of truth.

Episode hosts:
- Rename the `host` field to `hosts` to match `guests`. Add a
  resolveHosts() helper defaulting to [SHOW.defaultHost] ('Jim Ray'),
  and seed hosts: ['Jim Ray'] in the new-episode scaffold.

Add unit tests for podcast-feed, podcast-feed-content, and episodes.
