### PR TITLE
Update PDS admin interface availability information

### DIFF
--- a/src/app/[locale]/blog/pds-account-management/en.mdx
+++ b/src/app/[locale]/blog/pds-account-management/en.mdx
@@ -39,6 +39,6 @@ The new interface lives at the `/account` path on the PDS itself — for an acco
 
 And more!
 
-For a fuller walkthrough of this functionality, see the new [Account Management](/guides/account-management) guide.  As of today, the new PDS admin interface is available in both the newest release of [the reference PDS](https://github.com/bluesky-social/pds) (v0.4.5006), and on Bluesky's hosted [PDS entryway](https://docs.bsky.app/docs/advanced-guides/entryway). If you're running the reference PDS with the standard Docker deployment, it'll automatically update to the newest release.
+For a fuller walkthrough of this functionality, see the new [Account Management](/guides/account-management) guide.  As of today, the new PDS admin interface is available in the newest release of [the reference PDS](https://github.com/bluesky-social/pds) (v0.4.5006), and coming soon on Bluesky's hosted [PDS entryway](https://docs.bsky.app/docs/advanced-guides/entryway). If you're running the reference PDS with the standard Docker deployment, it'll automatically update to the newest release.
 
 This is only one of a few reference PDS updates we have planned for this summer — stay tuned for some observability dashboards and other monitoring tools for PDS deployment, coming soon!


### PR DESCRIPTION
The reference pds is the only one with the latest account management UI, bsky's entryway still needs to be updated to use the latest UI, this is happening soon-ish though (probably after email based 2FA.

@axfelix figured the article should probably reflect what's currently deployed. I wouldn't necessarily recommend using the entryway's account management UI right now until we roll out 0.8.0 of the oauth-provider-ui to it.