### PR TITLE
did:plc key terminology

### DIFF
--- a/src/app/[locale]/guides/account-recovery/en.mdx
+++ b/src/app/[locale]/guides/account-recovery/en.mdx
@@ -26,14 +26,14 @@ Most atproto accounts use `did:plc`, a DID method that relies on **rotation keys
 
 By adding your own rotation key with higher priority than your PDS's key, you gain the ability to update your identity independently, including pointing it to a new PDS if needed.
 
-## Recovery Keys
+## Rotation Keys
 
-Each DID document publishes two public keys: a signing key and a recovery key.
+Each DID uses two kinds of keys: a signing key and rotation keys.
 
-- **Signing key**: Asserts changes to the DID Document and to the user's data repository.
-- **Recovery key**: Asserts changes to the DID Document; may override the signing key within a **72-hour window**.
+- **Signing key**: Asserts changes to the user's data repository.
+- **Rotation key**: Asserts changes to the DID Document; can update the siging key.
 
-The signing key is entrusted to the PDS so that it can manage the user's data, but the recovery key is saved by the user, e.g. as a paper key. This makes it possible for the user to update their account to a new PDS without the original host's help.
+The signing key is entrusted to the PDS so that it can manage the user's data. A rotation key can also be saved by the user, e.g. as a paper key. This makes it possible for the user to update their account to a new PDS without the original host's help.
 
 ## Pre-registering a Key
 

--- a/src/app/[locale]/guides/account-recovery/en.mdx
+++ b/src/app/[locale]/guides/account-recovery/en.mdx
@@ -31,7 +31,7 @@ By adding your own rotation key with higher priority than your PDS's key, you ga
 Each DID uses two kinds of keys: a signing key and rotation keys.
 
 - **Signing key**: Asserts changes to the user's data repository.
-- **Rotation key**: Asserts changes to the DID Document; can update the siging key.
+- **Rotation key**: Asserts changes to the DID Document; can update the signing key.
 
 The signing key is entrusted to the PDS so that it can manage the user's data. A rotation key can also be saved by the user, e.g. as a paper key. This makes it possible for the user to update their account to a new PDS without the original host's help.
 


### PR DESCRIPTION
["Recovery Keys" section](https://atproto.com/guides/account-recovery#recovery-keys) contains several statements that may be confusing or inconsistent with [the current `did:plc` specification](https://web.plc.directory/spec/v0.1/did-plc). This PR updates the terminology and descriptions accordingly.

* "Recovery key" is an [older](https://github.com/bluesky-social/atproto-website/blob/060f6a4b6b401c92f1e539ccb6c988000ce7387f/content/specs/did-plc.md#signing-and-recovery-keys) name for what is now called a rotation key. My understanding is that the term is still sometimes used for an emergency rotation key controlled by the user, but there does not seem to be a reason to use a different term only in this section.
* DID documents no longer include rotation keys. They are still public, but they are stored in the operation log.
* The signing key cannot modify the DID document. A PDS holds a rotation key in order to update the DID document, but the repository signing key is separate.
* The 72-hour recovery window applies to nullifying PLC operations signed by lower-priority rotation keys, not directly to overriding the repository signing key.

As an alternative, this section could explain the model by separating the three roles more explicitly: the repository signing key, the PDS-controlled rotation key, and the user-controlled recovery/rotation key.
