### PR TITLE
Fix typo in security concerns section

### DIFF
--- a/src/app/[locale]/specs/sync/en.mdx
+++ b/src/app/[locale]/specs/sync/en.mdx
@@ -229,7 +229,7 @@ Event stream consumers need to track and persist the sequence number of events t
 
 General mitigations for resource exhaustion attacks are recommended: event rate-limits, data quotas per account, limits on data object sizes and deserialized data complexity, etc.
 
-Care should always be taken when making network requests to unknown or untrusted hosts, especially when the network locators for those host from from untrusted input. This includes validating URLs to not connect to local or internal hosts (including via HTTP redirects), avoiding SSRF in browser contexts, etc.
+Care should always be taken when making network requests to unknown or untrusted hosts, especially when the network locators for those host from untrusted input. This includes validating URLs to not connect to local or internal hosts (including via HTTP redirects), avoiding SSRF in browser contexts, etc.
 
 To prevent traffic amplification attacks, outbound network requests should be rate-limited by host. For example, identity resolution requests when consuming from the firehose, including DNS TXT traffic volume and DID resolution requests.
 


### PR DESCRIPTION
Corrected a typo that repeated `from` 2 times