### PR TITLE
Sync tutorials with statusphere-example-app updates

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-import "./.next/dev/types/root-params.d.ts";
+import "./.next/types/routes.d.ts";
+import "./.next/types/root-params.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/[locale]/guides/bot-tutorial/en.mdx
+++ b/src/app/[locale]/guides/bot-tutorial/en.mdx
@@ -51,7 +51,7 @@ If you aren't using an existing account to post from, you should [create a new a
 
 <S04 />
 
-If you want, you can view the downloaded Lexicon file at `lib/lexicons/app.bsky.post.json`. From here, you can run `lex build` to generate TypeScript types for all of your installed Lexicons:
+If you want, you can view the downloaded Lexicon file at `lexicons/app/bsky/feed/post.json`. From here, you can run `lex build` to generate TypeScript types for all of your installed Lexicons:
 
 <S05 />
 

--- a/src/app/[locale]/guides/bot-tutorial/ja.mdx
+++ b/src/app/[locale]/guides/bot-tutorial/ja.mdx
@@ -52,7 +52,7 @@ export const header = {
 
 <S04 />
 
-必要であれば、ダウンロードしたLexiconファイルを`lib/lexicons/app.bsky.post.json`で確認できます。ここから`lex build`を実行すると、インストール済みLexiconすべてに対してTypeScriptの型を生成できます。
+必要であれば、ダウンロードしたLexiconファイルを`lexicons/app/bsky/feed/post.json`で確認できます。ここから`lex build`を実行すると、インストール済みLexiconすべてに対してTypeScriptの型を生成できます。
 
 <S05 />
 

--- a/src/app/[locale]/guides/bot-tutorial/ko.mdx
+++ b/src/app/[locale]/guides/bot-tutorial/ko.mdx
@@ -44,7 +44,7 @@ export const header = {
 
 <S04 />
 
-원한다면 다운로드된 어휘집 파일을 `lib/lexicons/app.bsky.post.json`에서 확인할 수 있습니다. 여기서 `lex build`를 실행하여 설치된 모든 어휘집에 대한 TypeScript 타입을 생성할 수 있습니다:
+원한다면 다운로드된 어휘집 파일을 `lexicons/app/bsky/feed/post.json`에서 확인할 수 있습니다. 여기서 `lex build`를 실행하여 설치된 모든 어휘집에 대한 TypeScript 타입을 생성할 수 있습니다:
 
 <S05 />
 

--- a/src/app/[locale]/guides/bot-tutorial/pt.mdx
+++ b/src/app/[locale]/guides/bot-tutorial/pt.mdx
@@ -44,7 +44,7 @@ Se você não estiver usando uma conta existente para postar, deve [criar uma no
 
 <S04 />
 
-Se desejar, você pode visualizar o arquivo léxico baixado em `lib/lexicons/app.bsky.post.json`. A partir daqui, você pode executar `lex build` para gerar tipos TypeScript para todos os seus léxicos instalados:
+Se desejar, você pode visualizar o arquivo léxico baixado em `lexicons/app/bsky/feed/post.json`. A partir daqui, você pode executar `lex build` para gerar tipos TypeScript para todos os seus léxicos instalados:
 
 <S05 />
 

--- a/src/app/[locale]/guides/oauth-tutorial/_snippets/18-lib-db-migrations.mdx
+++ b/src/app/[locale]/guides/oauth-tutorial/_snippets/18-lib-db-migrations.mdx
@@ -1,5 +1,7 @@
 ```typescript
-import { Kysely, Migration, Migrator } from "kysely";
+import { Kysely } from "kysely";
+import { Migrator } from "kysely/migration";
+import type { Migration } from "kysely/migration";
 import { getDb } from ".";
 
 const migrations: Record<string, Migration> = {

--- a/src/app/[locale]/guides/statusphere-tutorial/_snippets/09-status-route.mdx
+++ b/src/app/[locale]/guides/statusphere-tutorial/_snippets/09-status-route.mdx
@@ -1,6 +1,6 @@
 ```typescript
 import { NextRequest, NextResponse } from "next/server";
-import { Client, type DatetimeString } from "@atproto/lex";
+import { Client, l } from "@atproto/lex";
 import { getSession } from "@/lib/auth/session";
 import { getOAuthClient } from "@/lib/auth/client";
 import * as xyz from "@/src/lexicons/xyz";
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest) {
   const oauthSession = await client.restore(session.did);
   const lexClient = new Client(oauthSession);
 
-  const createdAt = new Date().toISOString() as DatetimeString;
+  const createdAt = l.currentDatetimeString();
   const res = await lexClient.create(xyz.statusphere.status, {
     status,
     createdAt,

--- a/src/app/[locale]/guides/statusphere-tutorial/en.mdx
+++ b/src/app/[locale]/guides/statusphere-tutorial/en.mdx
@@ -67,7 +67,7 @@ You'll begin by adding Lexicons to your project.
 
 <S04 />
 
-If you want, you can view the downloaded Lexicon file at `lib/lexicons/xyz.statusphere.status.json`. From here, you can run `lex build` to generate TypeScript types for all of your installed Lexicons:
+If you want, you can view the downloaded Lexicon file at `lexicons/xyz/statusphere/status.json`. From here, you can run `lex build` to generate TypeScript types for all of your installed Lexicons:
 
 <S05 />
 

--- a/src/app/[locale]/guides/statusphere-tutorial/en.mdx
+++ b/src/app/[locale]/guides/statusphere-tutorial/en.mdx
@@ -39,13 +39,9 @@ You can find the source code for this tutorial in the [statusphere-example-app](
 This tutorial builds on top of the app created in our [OAuth with NextJS Tutorial](/guides/oauth-tutorial). You should have a completed NextJS OAuth app before starting this tutorial. If you want to skip that step, you can clone the completed OAuth app from the [Cookbook](https://github.com/bluesky-social/nextjs-oauth-tutorial/tree/129cf28b4146ae709e0dac43ce20154ab5237559).
 
 You should have installed:
-- Node.js 18-22.x
+- Node.js 20+
 - Go 1.25+
 - The pnpm package manager
-
-<Note>
-This tutorial currently doesn't work on Node 24.x because of a [Request bug](https://github.com/vercel/next.js/issues/90826).
-</Note>
 
 On platforms supported by [homebrew](https://brew.sh/), you can install them with:
 

--- a/src/app/[locale]/guides/statusphere-tutorial/ja.mdx
+++ b/src/app/[locale]/guides/statusphere-tutorial/ja.mdx
@@ -68,7 +68,7 @@ export const header = {
 
 <S04 />
 
-必要であれば、ダウンロードしたLexiconファイルを`lib/lexicons/xyz.statusphere.status.json`で確認できます。ここから`lex build`を実行すると、インストール済みLexiconすべてに対してTypeScriptの型を生成できます。
+必要であれば、ダウンロードしたLexiconファイルを`lexicons/xyz/statusphere/status.json`で確認できます。ここから`lex build`を実行すると、インストール済みLexiconすべてに対してTypeScriptの型を生成できます。
 
 <S05 />
 

--- a/src/app/[locale]/guides/statusphere-tutorial/ja.mdx
+++ b/src/app/[locale]/guides/statusphere-tutorial/ja.mdx
@@ -40,13 +40,9 @@ export const header = {
 このチュートリアルは、[OAuth with NextJSチュートリアル](/guides/oauth-tutorial)で作成したアプリをベースに進めます。開始前にNextJS OAuthアプリを完成させておいてください。この手順を省略したい場合は、[Cookbook](https://github.com/bluesky-social/nextjs-oauth-tutorial/tree/129cf28b4146ae709e0dac43ce20154ab5237559)から完成版をクローンできます。
 
 以下をインストールしておいてください。
-- Node.js 18〜22.x
+- Node.js 20以上
 - Go 1.25以上
 - pnpmパッケージマネージャー
-
-<Note>
-このチュートリアルは現在[Requestのバグ](https://github.com/vercel/next.js/issues/90826)のためNode 24.xでは動作しません。
-</Note>
 
 [homebrew](https://brew.sh/)に対応したプラットフォームでは、次のコマンドでインストールできます。
 

--- a/src/app/[locale]/guides/statusphere-tutorial/ko.mdx
+++ b/src/app/[locale]/guides/statusphere-tutorial/ko.mdx
@@ -56,7 +56,7 @@ export const header = {
 
 <S04 />
 
-원한다면 다운로드된 Lexicon 파일을 `lib/lexicons/ xyz.statusphere.status.json`에서 확인할 수 있습니다. 여기서 `lex build`를 실행하면 설치된 모든 레식콘에 대한 TypeScript 타입을 생성할 수 있습니다:
+원한다면 다운로드된 Lexicon 파일을 `lexicons/xyz/statusphere/status.json`에서 확인할 수 있습니다. 여기서 `lex build`를 실행하면 설치된 모든 레식콘에 대한 TypeScript 타입을 생성할 수 있습니다:
 
 <S05 />
 

--- a/src/app/[locale]/guides/statusphere-tutorial/ko.mdx
+++ b/src/app/[locale]/guides/statusphere-tutorial/ko.mdx
@@ -35,7 +35,7 @@ export const header = {
 ## 필수 조건
 본 튜토리얼은 [NextJS를 활용한 OAuth 튜토리얼](/guides/oauth-tutorial)에서 생성한 앱을 기반으로 합니다. 시작하기 전에 NextJS OAuth 앱을 완성해 두셔야 합니다. 해당 단계를 건너뛰고 싶다면 [Cookbook](https://github.com/bluesky-social/nextjs-oauth-tutorial/tree/129cf28b4146ae709e0dac43ce20154ab5237559)에서 완성된 OAuth 앱을 복제할 수 있습니다.
 다음이 설치되어 있어야 합니다:
-- Node.js 18 이상
+- Node.js 20 이상
 - Go 1.25 이상
 - pnpm 패키지 관리자
 [homebrew](https://brew.sh/)가 지원하는 플랫폼에서는 다음 명령어로 설치할 수 있습니다:

--- a/src/app/[locale]/guides/statusphere-tutorial/pt.mdx
+++ b/src/app/[locale]/guides/statusphere-tutorial/pt.mdx
@@ -56,7 +56,7 @@ Você começará adicionando léxicos ao seu projeto.
 
 <S04 />
 
-Se desejar, você pode visualizar o arquivo Lexicon baixado em `lib/lexicons/ xyz.statusphere.status.json`. A partir daqui, você pode executar `lex build` para gerar tipos TypeScript para todos os seus léxicos instalados:
+Se desejar, você pode visualizar o arquivo Lexicon baixado em `lexicons/xyz/statusphere/status.json`. A partir daqui, você pode executar `lex build` para gerar tipos TypeScript para todos os seus léxicos instalados:
 
 <S05 />
 

--- a/src/app/[locale]/guides/statusphere-tutorial/pt.mdx
+++ b/src/app/[locale]/guides/statusphere-tutorial/pt.mdx
@@ -35,7 +35,7 @@ Você pode encontrar o código-fonte deste tutorial, juntamente com outros proje
 ## Pré-requisitos
 Este tutorial se baseia no aplicativo criado em nosso [Tutorial OAuth com NextJS](/guides/oauth-tutorial). Você deve ter um aplicativo NextJS OAuth concluído antes de iniciar este tutorial. Se quiser pular essa etapa, você pode clonar o aplicativo OAuth concluído do [Cookbook] (https://github.com/bluesky-social/nextjs-oauth-tutorial/tree/129cf28b4146ae709e0dac43ce20154ab5237559).
 Você deve ter instalado:
-- Node.js 18+
+- Node.js 20+
 - Go 1.25+
 - O gerenciador de pacotes pnpm
 Em plataformas compatíveis com [homebrew](https://brew.sh/), você pode instalá-los com:


### PR DESCRIPTION
Aligns the OAuth NextJS tutorial and Statusphere tutorial with recent changes in [statusphere-example-app](https://github.com/bluesky-social/statusphere-example-app), plus a few doc bugs found along the way.

_(Rebased on main — the `allowedDevOrigins` and `insertStatus` race fixes originally in this PR have since landed on main separately and are no longer part of this diff.)_

## OAuth tutorial (`/guides/oauth-tutorial`)

- **Fix broken kysely import** — kysely 0.29 moved `Migration`/`Migrator` to the `kysely/migration` subpath export (verified against 0.29.5). Since the tutorial installs kysely unpinned, anyone following it today hits a compile error at the migrations step. Mirrors statusphere-example-app@4bd8227.

## Statusphere tutorial (`/guides/statusphere-tutorial`)

- **Use `l.currentDatetimeString()`** instead of `new Date().toISOString() as DatetimeString`, per `@atproto/lex` ≥ 0.2.2.
- **Correct the downloaded lexicon path** (all locales) — `lex install` writes to `lexicons/xyz/statusphere/status.json`. Also removes a stray space in the ko/pt paths.
- **Remove the stale Node 24 warning** (vercel/next.js#90826) — no longer reproduces; fixed on the undici side between Node 24.14 and 24.18. Node prerequisites aligned to "20+" across locales.

## Bot tutorial (`/guides/bot-tutorial`)

- **Correct the downloaded lexicon path** (all locales) — `lex install app.bsky.feed.post` writes `lexicons/app/bsky/feed/post.json`; the docs pointed at `lib/lexicons/app.bsky.post.json`, which has both the wrong layout and a non-existent NSID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
