### PR TITLE
Dedupe page metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,45 @@ Because the record's canonical URL only resolves after the post is merged and
 deployed, the publish is metadata-only and idempotent — re-running
 `npm run blog ssite <slug>` after edits updates the same record.
 
+### Content page structure
+
+Every content route — blog posts, episodes, guides, specs — is a `page.tsx` next
+to an `en.mdx`. Two rules hold across all 131 of them:
+
+**Route metadata comes from the MDX header.** `page.tsx` exports
+`generateMetadata()` reading `header.title` / `header.description`, rather than
+repeating them in a `metadata` object. That object used to be a second copy that
+nothing kept in sync — the studio and CLIs rewrite `en.mdx` and the
+`posts.ts`/`episodes.ts` entry but never touched `page.tsx` — which left episodes
+whose `<h1>` and OG preview disagreed. There is now nothing to keep in sync.
+
+**`en.mdx` is imported statically.** A template-literal `import()` makes webpack
+build a *context module*, so the route has no dependency edge on the specific
+file and editing content doesn't hot-reload until you restart the dev server.
+A static import fixes that.
+
+Which shape a page uses depends on whether its area is translated. Only
+`guides`, `articles`, and `specs` are (per `crowdin.yml`, into ja/ko/pt):
+
+- **Untranslated** — blog, off-protocol, about — import `en.mdx` and nothing
+  else. No locale resolution at all.
+- **Translated** import English statically for the fallback, the metadata, and
+  the module edge, and resolve other locales per request.
+
+Route metadata stays English for every locale, which is the long-standing
+behaviour: translated pages carry translated headers, but `<title>` and OG come
+from English. Reading each locale's own header would localise them — a worthwhile
+follow-up, and a visible change across ~70 pages.
+
+Two pages predate the `header` convention and export `metadata` from their MDX
+instead (`guides/data-validation`, `specs/permission`); they read that. The
+former also renders its MDX directly, with no `<Page>` wrapper, because its
+content supplies its own heading.
+
+`mdx.d.ts` types the named MDX exports. `@types/mdx` only types the default
+export, and nothing surfaced that before, because the dynamic import resolved to
+`any`.
+
 #### Author bylines
 
 Individual blog post pages display an author byline below the date. Named authors with a Bluesky DID are linked to their `bsky.app` profile.
@@ -156,12 +195,15 @@ Each editor has a switch to the other in its sidebar.
 - **Smart typography on save.** Titles and descriptions are stored with curly
   quotes, em/en dashes, and ellipses, matching what the prose pipeline does to
   MDX bodies at render time. Those two fields are plain JS strings in
-  `posts.ts`/`episodes.ts` and `page.tsx` metadata, so remark never sees them —
-  without this a title reads `"Like This"` while the body around it is curled.
-  The editor shows the transformed value after saving. Slugs, dates, URLs, and
-  author/host names are left exactly as typed. `npm run blog create` and
-  `npm run podcast create` apply the same transform, so it doesn't matter which
-  tool you author with.
+  `posts.ts`/`episodes.ts`, so remark never sees them — without this a title
+  reads `"Like This"` while the body around it is curled. The editor shows the
+  transformed value after saving. Slugs, dates, URLs, and author/host names are
+  left exactly as typed. `npm run blog create` and `npm run podcast create` apply
+  the same transform, so it doesn't matter which tool you author with.
+- **The title lives in two places, not three.** `page.tsx` derives its route
+  metadata from the MDX header via `generateMetadata()`, so editing a title
+  updates `<title>` and the OG preview without anything having to copy it there.
+  See [Content page structure](#content-page-structure).
 
 #### Credentials
 

--- a/README.md
+++ b/README.md
@@ -123,17 +123,26 @@ Which shape a page uses depends on whether its area is translated. Only
 
 - **Untranslated** — blog, off-protocol, about — import `en.mdx` and nothing
   else. No locale resolution at all.
-- **Translated** import English statically for the fallback, the metadata, and
-  the module edge, and resolve other locales per request.
+- **Translated** import English statically for the fallback and the module edge,
+  and resolve the requested locale per request.
 
-Route metadata stays English for every locale, which is the long-standing
-behaviour: translated pages carry translated headers, but `<title>` and OG come
-from English. Reading each locale's own header would localise them — a worthwhile
-follow-up, and a visible change across ~70 pages.
+Both share two helpers in `src/lib/localizedMdx.ts`, so the fallback rule and the
+header lookup are defined and tested once rather than regenerated into 130 route
+files: `resolveLocaleMdx()` (English short-circuits; a locale with no translated
+file falls back rather than 500ing) and `mdxRouteMetadata()`. The dynamic
+`import()` still lives in each page, since webpack resolves it relative to that
+file.
+
+**Route metadata is localised.** `/ja/guides/account-management` reports
+`アカウント管理`, and a page with no translation for the requested locale falls
+back to English. The ` - AT Protocol` suffix comes from the root layout and stays
+English.
 
 Two pages predate the `header` convention and export `metadata` from their MDX
-instead (`guides/data-validation`, `specs/permission`); they read that. The
-former also renders its MDX directly, with no `<Page>` wrapper, because its
+instead (`guides/data-validation`, `specs/permission`) — `mdxRouteMetadata()`
+prefers `header` and falls back to `metadata`, so both conventions work, including
+`specs/permission`, whose English file uses one and its Korean the other. The
+former page also renders its MDX directly, with no `<Page>` wrapper, because its
 content supplies its own heading.
 
 `mdx.d.ts` types the named MDX exports. `@types/mdx` only types the default

--- a/mdx.d.ts
+++ b/mdx.d.ts
@@ -3,20 +3,37 @@
 // *script* file (no top-level import/export) for this to be an ambient
 // augmentation rather than a module one.
 //
-// Needed because page.tsx reads `header` to build its metadata. Until that
-// change, pages imported MDX through a template-literal `import()`, which TS
-// resolves to `any` — so a missing type was never surfaced.
+// Needed because page.tsx now reads `header` to build its metadata. Before that,
+// pages imported MDX through a template-literal `import()`, which TS resolves to
+// `any` — so the absence of these types was never surfaced.
 
 declare module '*.mdx' {
   /**
-   * `export const header` from the MDX file. Typed loosely on purpose: blog
-   * posts, episodes, guides, and specs all carry different extra fields, and
-   * only title/description are read by shared code. Optional because plenty of
-   * MDX files — code snippets, transcripts — have no header at all.
+   * `export const header` from the MDX file.
+   *
+   * Typed as `any`, deliberately. Blog posts, episodes, guides, and specs all
+   * carry different header shapes, and an ambient declaration can't vary per
+   * file. A structural type doesn't work either: `EpisodePage` requires
+   * `episodeNumber`, `date`, `pubDate`, and `audioUrl`, and no index signature
+   * or optional-property type satisfies required props — the alternative was a
+   * double cast in every episode page, which asserts just as much as `any` does
+   * while looking more rigorous.
+   *
+   * This is not a regression: the dynamic import these pages used before
+   * resolved to `any` too. Header shape is enforced where headers are *written*
+   * — `EpisodeFields` and `OwnedFields` in src/lib/studio, both covered by
+   * tests — rather than where they're read.
    */
-  export const header:
-    | ({ title: string; description: string } & Record<string, unknown>)
-    | undefined
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export const header: any
+
+  /**
+   * `export const metadata` — a second, older convention used by two pages
+   * (guides/data-validation, specs/permission) whose MDX renders its own `# h1`
+   * and so carries no `header`. Same `any` reasoning as above.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export const metadata: any
 
   /** Section list injected by the recma plugin, consumed by the section nav. */
   export const sections: Array<{ id: string; title: string }> | undefined

--- a/mdx.d.ts
+++ b/mdx.d.ts
@@ -1,0 +1,23 @@
+// Types for the named exports our MDX files carry. @types/mdx only types the
+// default export; everything else has to be declared here, and it must stay a
+// *script* file (no top-level import/export) for this to be an ambient
+// augmentation rather than a module one.
+//
+// Needed because page.tsx reads `header` to build its metadata. Until that
+// change, pages imported MDX through a template-literal `import()`, which TS
+// resolves to `any` — so a missing type was never surfaced.
+
+declare module '*.mdx' {
+  /**
+   * `export const header` from the MDX file. Typed loosely on purpose: blog
+   * posts, episodes, guides, and specs all carry different extra fields, and
+   * only title/description are read by shared code. Optional because plenty of
+   * MDX files — code snippets, transcripts — have no header at all.
+   */
+  export const header:
+    | ({ title: string; description: string } & Record<string, unknown>)
+    | undefined
+
+  /** Section list injected by the recma plugin, consumed by the section nav. */
+  export const sections: Array<{ id: string; title: string }> | undefined
+}

--- a/scripts/new-blog-post.mjs
+++ b/scripts/new-blog-post.mjs
@@ -140,6 +140,7 @@ export async function main(...args) {
   // blog posts aren't translated and the module edge is what makes content edits
   // hot-reload.
   const pageContent = `import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -147,10 +148,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/scripts/new-blog-post.mjs
+++ b/scripts/new-blog-post.mjs
@@ -135,21 +135,26 @@ export async function main(...args) {
   fs.mkdirSync(postDir, { recursive: true })
 
   // Create page.tsx
+  // No title/description here: the route reads them from the MDX header, so
+  // page.tsx can't drift from the content. en.mdx is imported statically because
+  // blog posts aren't translated and the module edge is what makes content edits
+  // hot-reload.
   const pageContent = `import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: '${title.replace(/'/g, "\\'")}',
-  description: '${description.replace(/'/g, "\\'")}',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(\`./\${(await params).locale}.mdx\`)
-  } catch (error) {
-    Content = await import(\`./en.mdx\`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }
 `
   fs.writeFileSync(path.join(postDir, 'page.tsx'), pageContent)

--- a/scripts/new-episode.mjs
+++ b/scripts/new-episode.mjs
@@ -220,29 +220,31 @@ export async function main() {
   fs.mkdirSync(episodeDir, { recursive: true })
 
   // Write page.tsx
+  // No title/description here: the route reads them from the MDX header, so
+  // page.tsx can't drift from the content. en.mdx and transcript.mdx are static
+  // imports because episodes aren't translated, and the module edge is what makes
+  // show-notes edits hot-reload.
   const pageTsx = `import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: '${title.replace(/'/g, "\\'")}',
-  description: '${description.replace(/'/g, "\\'")}',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(\`./\${(await params).locale}.mdx\`).catch(
-    () => import(\`./en.mdx\`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(\`./transcript.mdx\`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/scripts/new-episode.mjs
+++ b/scripts/new-episode.mjs
@@ -225,6 +225,7 @@ export async function main() {
   // imports because episodes aren't translated, and the module edge is what makes
   // show-notes edits hot-reload.
   const pageTsx = `import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -233,10 +234,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/about/trademarks/atproto-trademark-policy/page.tsx
+++ b/src/app/[locale]/about/trademarks/atproto-trademark-policy/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function HomePage() {

--- a/src/app/[locale]/about/trademarks/atproto-trademark-policy/page.tsx
+++ b/src/app/[locale]/about/trademarks/atproto-trademark-policy/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Atproto Trademark Policy',
-  description: 'Trademark policy for the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function HomePage() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/about/trademarks/page.tsx
+++ b/src/app/[locale]/about/trademarks/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function HomePage() {

--- a/src/app/[locale]/about/trademarks/page.tsx
+++ b/src/app/[locale]/about/trademarks/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Trademarks',
-  description: 'Trademark and brand usage guidelines for the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function HomePage() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/articles/atproto-ethos/page.tsx
+++ b/src/app/[locale]/articles/atproto-ethos/page.tsx
@@ -1,17 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Atproto Ethos',
-  description:
-    'A deep dive into the philosophical and aesthetic principles underlying the design of AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/articles/atproto-ethos/page.tsx
+++ b/src/app/[locale]/articles/atproto-ethos/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/articles/atproto-for-distsys-engineers/page.tsx
+++ b/src/app/[locale]/articles/atproto-for-distsys-engineers/page.tsx
@@ -1,17 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Atproto for distributed systems engineers',
-  description:
-    "AT Protocol is the tech developed at Bluesky for open social networking. In this article we're going to explore atproto from the perspective of distributed backend engineering.",
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/articles/atproto-for-distsys-engineers/page.tsx
+++ b/src/app/[locale]/articles/atproto-for-distsys-engineers/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/blog/2024-protocol-roadmap/page.tsx
+++ b/src/app/[locale]/blog/2024-protocol-roadmap/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/2024-protocol-roadmap/page.tsx
+++ b/src/app/[locale]/blog/2024-protocol-roadmap/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: '2024 Protocol Roadmap',
-  description: 'An update on our progress and our general goals and focus for the coming months.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/2025-protocol-roadmap-spring/page.tsx
+++ b/src/app/[locale]/blog/2025-protocol-roadmap-spring/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/2025-protocol-roadmap-spring/page.tsx
+++ b/src/app/[locale]/blog/2025-protocol-roadmap-spring/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: '2025 Protocol Roadmap (Spring and Summer)',
-  description: 'Updates to the AT Protocol roadmap, including Sync v1.1, auth scopes, PDS account management, and more.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/2026-spring-roadmap/page.tsx
+++ b/src/app/[locale]/blog/2026-spring-roadmap/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/2026-spring-roadmap/page.tsx
+++ b/src/app/[locale]/blog/2026-spring-roadmap/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'AT Protocol Roadmap (Spring 2026)',
-  description: 'Updates to the AT Protocol roadmap, including Permissioned Data and Account Experience.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/at-protocol-trademark/page.tsx
+++ b/src/app/[locale]/blog/at-protocol-trademark/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/at-protocol-trademark/page.tsx
+++ b/src/app/[locale]/blog/at-protocol-trademark/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'AT Protocol Trademark',
-  description: 'Bluesky now owns the AT Protocol trademark to help make sure it can be used as widely and responsibly as possible.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/atmospheric-website/page.tsx
+++ b/src/app/[locale]/blog/atmospheric-website/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function AtmosphericWebsitePage() {

--- a/src/app/[locale]/blog/atmospheric-website/page.tsx
+++ b/src/app/[locale]/blog/atmospheric-website/page.tsx
@@ -1,17 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Build an Atmospheric Website',
-  description:
-    'Watch the episode and follow along to build a website on AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function AtmosphericWebsitePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function AtmosphericWebsitePage() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/atproto-grants-recipients/page.tsx
+++ b/src/app/[locale]/blog/atproto-grants-recipients/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/atproto-grants-recipients/page.tsx
+++ b/src/app/[locale]/blog/atproto-grants-recipients/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Meet the second batch of AT Protocol Grant Recipients',
-  description: 'Announcing the second batch of AT Protocol grant recipients, distributing $4,800 total in grants.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/atproto-grants/page.tsx
+++ b/src/app/[locale]/blog/atproto-grants/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/atproto-grants/page.tsx
+++ b/src/app/[locale]/blog/atproto-grants/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Announcing AT Protocol Grants',
-  description: 'Announcing the AT Protocol Grants program, aimed at fostering the growth and sustainability of the atproto developer ecosystem.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/bgs-and-did-doc/page.tsx
+++ b/src/app/[locale]/blog/bgs-and-did-doc/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Bluesky BGS and DID Document Formatting Changes',
-  description: 'Protocol and infrastructure changes including the BGS firehose and DID document formatting updates.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/bgs-and-did-doc/page.tsx
+++ b/src/app/[locale]/blog/bgs-and-did-doc/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/block-implementation/page.tsx
+++ b/src/app/[locale]/blog/block-implementation/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/block-implementation/page.tsx
+++ b/src/app/[locale]/blog/block-implementation/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Why are blocks on Bluesky public?',
-  description: 'The technical implementation of public blocks and some possibilities for more privacy preserving block implementations.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/building-on-atproto/page.tsx
+++ b/src/app/[locale]/blog/building-on-atproto/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/building-on-atproto/page.tsx
+++ b/src/app/[locale]/blog/building-on-atproto/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Building on the AT Protocol',
-  description: 'What you can already build on atproto, and what you can expect soon.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/call-for-developers/page.tsx
+++ b/src/app/[locale]/blog/call-for-developers/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/call-for-developers/page.tsx
+++ b/src/app/[locale]/blog/call-for-developers/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Bluesky Call for Developers',
-  description: 'Bluesky is an open social network built on the AT Protocol. If you’re a developer interested in building on atproto, we’d love to hear from you.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/create-post/page.tsx
+++ b/src/app/[locale]/blog/create-post/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/create-post/page.tsx
+++ b/src/app/[locale]/blog/create-post/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Posting via the Bluesky API',
-  description: 'A guide to creating posts via the Bluesky API, including mentions, links, replies, quote posts, and image embeds.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/federation-sandbox/page.tsx
+++ b/src/app/[locale]/blog/federation-sandbox/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/federation-sandbox/page.tsx
+++ b/src/app/[locale]/blog/federation-sandbox/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Federation Developer Sandbox Guidelines',
-  description: 'Guidelines for the atproto federation developer sandbox environment.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/going-off-protocol/page.tsx
+++ b/src/app/[locale]/blog/going-off-protocol/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/going-off-protocol/page.tsx
+++ b/src/app/[locale]/blog/going-off-protocol/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Going Off Protocol',
-  description: 'We’re expanding our office hours livestream. Look for it wherever you get your podcasts.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/indexing-standard-site/page.tsx
+++ b/src/app/[locale]/blog/indexing-standard-site/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/indexing-standard-site/page.tsx
+++ b/src/app/[locale]/blog/indexing-standard-site/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Indexing Standard Site',
-  description: 'This guest post from Steve Simkins, creator of Sequoia and docs.surf, outlines the strategy he used to index standard.site records.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/introducing-hubble-a-public-mirror-for-the-whole-atmosphere/page.tsx
+++ b/src/app/[locale]/blog/introducing-hubble-a-public-mirror-for-the-whole-atmosphere/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Introducing Hubble: A Public Mirror for the Whole Atmosphere',
-  description: 'Bluesky is providing a grant to the creator of Microcosm to build a full mirror of public data on the Atmosphere to help make the network more resilient.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/introducing-hubble-a-public-mirror-for-the-whole-atmosphere/page.tsx
+++ b/src/app/[locale]/blog/introducing-hubble-a-public-mirror-for-the-whole-atmosphere/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/introducing-tap/page.tsx
+++ b/src/app/[locale]/blog/introducing-tap/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/introducing-tap/page.tsx
+++ b/src/app/[locale]/blog/introducing-tap/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Introducing Tap: Repository Synchronization Made Simple',
-  description: 'We recently released Tap, a tool designed to handle the hard parts of repo synchronization, so you can focus on building your application.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/jetstream/page.tsx
+++ b/src/app/[locale]/blog/jetstream/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/jetstream/page.tsx
+++ b/src/app/[locale]/blog/jetstream/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Introducing Jetstream',
-  description: 'Introducing Jetstream, an alternative streaming solution with simple JSON encoding and reduced bandwidth.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/kicking-off-the-atp-working-group/page.tsx
+++ b/src/app/[locale]/blog/kicking-off-the-atp-working-group/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/kicking-off-the-atp-working-group/page.tsx
+++ b/src/app/[locale]/blog/kicking-off-the-atp-working-group/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Kicking off the ATP Working Group at the IETF',
-  description: 'The Authenticated Transfer Protocol working group has been created at the IETF. Now that we have a charter, we are looking forward to participation from the broader ATP ecosystem. ',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/label-grants/page.tsx
+++ b/src/app/[locale]/blog/label-grants/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/label-grants/page.tsx
+++ b/src/app/[locale]/blog/label-grants/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Labeling Services Microgrants',
-  description: 'Launching microgrants for labeling services on Bluesky to support moderation and community safety.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/looking-back-2024/en.mdx
+++ b/src/app/[locale]/blog/looking-back-2024/en.mdx
@@ -5,8 +5,6 @@ export const header = {
   author: 'AT Protocol Team',
 }
 
-# Looking Back At 2024 AT Protocol Development
-
 In May 2024, we published a 2024 [Protocol Roadmap](https://docs.bsky.app/blog/2024-protocol-roadmap), and we want to give an end-of-year update. We will follow up soon with a forward-looking roadmap for 2025.
 
 In the big picture, most of the public data aspects of the protocol have now been designed and implemented. The last missing pieces are nearing completion, and we do not foresee disruptive changes or additions which would impact interoperability. Now is a great time to start building on the protocol and assembling independent infrastructure.

--- a/src/app/[locale]/blog/looking-back-2024/page.tsx
+++ b/src/app/[locale]/blog/looking-back-2024/page.tsx
@@ -1,16 +1,13 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
-// Blog posts aren't translated (crowdin.yml covers guides/articles/specs only),
-// so this imports en.mdx statically. That gives the route a real module-graph
-// edge — which is what lets a content edit hot-reload — and lets the metadata
-// come from the header instead of being a second copy that can drift from it.
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/looking-back-2024/page.tsx
+++ b/src/app/[locale]/blog/looking-back-2024/page.tsx
@@ -1,16 +1,18 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Looking Back At 2024 AT Protocol Development',
-  description: 'A lot of progress was made on the protocol in 2024, here’s a look at the big milestones',
+// Blog posts aren't translated (crowdin.yml covers guides/articles/specs only),
+// so this imports en.mdx statically. That gives the route a real module-graph
+// edge — which is what lets a content edit hot-reload — and lets the metadata
+// come from the header instead of being a second copy that can drift from it.
+
+export function generateMetadata() {
+  return {
+    title: content.header?.title,
+    description: content.header?.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/looking-back-2024/page.tsx
+++ b/src/app/[locale]/blog/looking-back-2024/page.tsx
@@ -8,8 +8,8 @@ import * as content from './en.mdx'
 
 export function generateMetadata() {
   return {
-    title: content.header?.title,
-    description: content.header?.description,
+    title: content.header.title,
+    description: content.header.description,
   }
 }
 

--- a/src/app/[locale]/blog/network-account-management/page.tsx
+++ b/src/app/[locale]/blog/network-account-management/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/network-account-management/page.tsx
+++ b/src/app/[locale]/blog/network-account-management/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Network Account Management',
-  description: 'We recently shipped new functionality to the PDS reference implementation (and Bluesky’s hosting service) which provides a web interface to create and manage accounts directly on the PDS itself.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/new-site-2026/page.tsx
+++ b/src/app/[locale]/blog/new-site-2026/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/new-site-2026/page.tsx
+++ b/src/app/[locale]/blog/new-site-2026/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Welcome to the new atproto.com',
-  description: 'We’ve updated just about everything about atproto.com to make it easier for developers to just build things.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/npmx-alpha-launch/page.tsx
+++ b/src/app/[locale]/blog/npmx-alpha-launch/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/npmx-alpha-launch/page.tsx
+++ b/src/app/[locale]/blog/npmx-alpha-launch/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Supporting the npmx Alpha Launch',
-  description: 'The launch of npmx is an incredible showcase for how open source communities can build quickly on top of atproto.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/oauth-atproto/page.tsx
+++ b/src/app/[locale]/blog/oauth-atproto/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/oauth-atproto/page.tsx
+++ b/src/app/[locale]/blog/oauth-atproto/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'OAuth for AT Protocol',
-  description: 'Releasing the initial specification of OAuth for AT Protocol, the primary authentication and authorization system going forward.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/oauth-improvements/page.tsx
+++ b/src/app/[locale]/blog/oauth-improvements/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/oauth-improvements/page.tsx
+++ b/src/app/[locale]/blog/oauth-improvements/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'OAuth Improvements',
-  description: 'We’ve been making improvements to the end-user and developer experiences with atproto OAuth.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/pds-account-management/page.tsx
+++ b/src/app/[locale]/blog/pds-account-management/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'The Reference PDS Gets an Account Management Page',
-  description: 'Announcing the addition of an account management interface to the reference PDS',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/pds-account-management/page.tsx
+++ b/src/app/[locale]/blog/pds-account-management/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/pinned-posts/page.tsx
+++ b/src/app/[locale]/blog/pinned-posts/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/pinned-posts/page.tsx
+++ b/src/app/[locale]/blog/pinned-posts/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Lexicons, Pinned Posts, and Interoperability',
-  description: 'A discussion of Lexicons, schema extensions, and lessons learned from the pinned posts feature collision.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/plc-directory-org/page.tsx
+++ b/src/app/[locale]/blog/plc-directory-org/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/plc-directory-org/page.tsx
+++ b/src/app/[locale]/blog/plc-directory-org/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Creating an Independent Public Ledger of Credentials (PLC) Directory Organization',
-  description: 'As the next step of maturing governance of the PLC identity system, Bluesky Social PBC is supporting the creation of an independent organization to operate the PLC directory.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/plc-replicas/page.tsx
+++ b/src/app/[locale]/blog/plc-replicas/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'PLC Read Replicas',
-  description: 'Introducing a self-hostable did:plc read-replica service',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/plc-replicas/page.tsx
+++ b/src/app/[locale]/blog/plc-replicas/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/protocol-check-in-fall-2025/page.tsx
+++ b/src/app/[locale]/blog/protocol-check-in-fall-2025/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/protocol-check-in-fall-2025/page.tsx
+++ b/src/app/[locale]/blog/protocol-check-in-fall-2025/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Protocol Check-in (Fall 2025)',
-  description: 'The Atmosphere is thriving, here’s a closer look',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/protocol-roadmap/page.tsx
+++ b/src/app/[locale]/blog/protocol-roadmap/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/protocol-roadmap/page.tsx
+++ b/src/app/[locale]/blog/protocol-roadmap/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: '2023 Protocol Roadmap',
-  description: 'The current AT Protocol development plan through to a version one release.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/relay-ops/page.tsx
+++ b/src/app/[locale]/blog/relay-ops/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/relay-ops/page.tsx
+++ b/src/app/[locale]/blog/relay-ops/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Relay Operational Updates',
-  description: 'Updates on changes to Bluesky relay servers and guidance for firehose consumers.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/relay-rollout/page.tsx
+++ b/src/app/[locale]/blog/relay-rollout/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/relay-rollout/page.tsx
+++ b/src/app/[locale]/blog/relay-rollout/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Upcoming Relay Transition',
-  description: 'What the new relay rollout means for consumers of the firehose.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/relay-updates-sync-v1-1/page.tsx
+++ b/src/app/[locale]/blog/relay-updates-sync-v1-1/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/relay-updates-sync-v1-1/page.tsx
+++ b/src/app/[locale]/blog/relay-updates-sync-v1-1/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Relay Updates for Sync v1.1',
-  description: 'Updates to our reference implementation of the relay support sync version 1.1',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/repo-export/page.tsx
+++ b/src/app/[locale]/blog/repo-export/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Download and Parse Repository Exports',
-  description: 'How to export and parse a data repository as a CAR file.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/repo-export/page.tsx
+++ b/src/app/[locale]/blog/repo-export/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/repo-sync-update/page.tsx
+++ b/src/app/[locale]/blog/repo-sync-update/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/repo-sync-update/page.tsx
+++ b/src/app/[locale]/blog/repo-sync-update/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Updates to Repository Sync Semantics',
-  description: 'Announcing updates to atproto repositories that remove history and replace it with a logical clock.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/report-based-moderation/page.tsx
+++ b/src/app/[locale]/blog/report-based-moderation/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/report-based-moderation/page.tsx
+++ b/src/app/[locale]/blog/report-based-moderation/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Report-Based Moderation in Ozone',
-  description: 'A report-centric workflow for Ozone with new queues, assignments, real-time collaboration, and a per-report activity log.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/rpg-actor/page.tsx
+++ b/src/app/[locale]/blog/rpg-actor/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'rpg.actor — What if Your RPG Character Could Log In to Any Game?',
-  description: 'Carrying your adventures through many worlds with the AT Protocol',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/rpg-actor/page.tsx
+++ b/src/app/[locale]/blog/rpg-actor/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/self-host-federation/page.tsx
+++ b/src/app/[locale]/blog/self-host-federation/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/self-host-federation/page.tsx
+++ b/src/app/[locale]/blog/self-host-federation/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Early Access Federation for Self-Hosters',
-  description: 'Releasing an early-access version of federation intended for self-hosters and developers.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/serving-the-for-you-feed/page.tsx
+++ b/src/app/[locale]/blog/serving-the-for-you-feed/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Serving the For You Feed',
-  description: 'How the maintainer of the popular For You feed serves it from their living room!',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/serving-the-for-you-feed/page.tsx
+++ b/src/app/[locale]/blog/serving-the-for-you-feed/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/standard-site-bluesky-timeline/page.tsx
+++ b/src/app/[locale]/blog/standard-site-bluesky-timeline/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/standard-site-bluesky-timeline/page.tsx
+++ b/src/app/[locale]/blog/standard-site-bluesky-timeline/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Now in your timeline: Standard.site brings richer previews from across the open web',
-  description: 'Articles published with this community-built format now receive richer treatment in the Bluesky app',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/taking-at-to-the-ietf/page.tsx
+++ b/src/app/[locale]/blog/taking-at-to-the-ietf/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Taking AT to the IETF',
-  description: 'We recently posted two drafts to the IETF Data Tracker. This is the first major step towards standardizing parts of AT in an effort to establish long-term governance for the protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/taking-at-to-the-ietf/page.tsx
+++ b/src/app/[locale]/blog/taking-at-to-the-ietf/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/ts-sdk-upgrades/page.tsx
+++ b/src/app/[locale]/blog/ts-sdk-upgrades/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/ts-sdk-upgrades/page.tsx
+++ b/src/app/[locale]/blog/ts-sdk-upgrades/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'TypeScript SDK Upgrades',
-  description: 'Modernizing our TS packages and moving the lex SDK closer to 1.0',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/blog/working-to-decentralize-fedcm/page.tsx
+++ b/src/app/[locale]/blog/working-to-decentralize-fedcm/page.tsx
@@ -1,4 +1,5 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -6,10 +7,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/app/[locale]/blog/working-to-decentralize-fedcm/page.tsx
+++ b/src/app/[locale]/blog/working-to-decentralize-fedcm/page.tsx
@@ -1,16 +1,17 @@
 import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: 'Working to Decentralize FedCM',
-  description: 'Bluesky Social PBC have given a grant to Emelia Smith, an Invited Expert with the FedID Working Group, to work on FedCM with the goal of making FedCM really work for the decentralized web.',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/about-oauth/page.tsx
+++ b/src/app/[locale]/guides/about-oauth/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/about-oauth/page.tsx
+++ b/src/app/[locale]/guides/about-oauth/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'About OAuth - AT Protocol Docs',
-  description: 'OAuth implementation patterns for atproto applications.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/account-lifecycle/page.tsx
+++ b/src/app/[locale]/guides/account-lifecycle/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/account-lifecycle/page.tsx
+++ b/src/app/[locale]/guides/account-lifecycle/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Accounts and deletions',
-  description: 'How account lifecycles and deletions work in AT Protocol',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/account-management/page.tsx
+++ b/src/app/[locale]/guides/account-management/page.tsx
@@ -1,16 +1,25 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Account Management',
-  description: 'How to manage your Atmosphere account',
+// Guides are translated, so the locale variant is still resolved at request
+// time. English is imported statically anyway: it's the fallback, it's the file
+// authors actually edit (so it gets a real module-graph edge for hot reload),
+// and its header supplies the metadata rather than a duplicated copy.
+//
+// Metadata stays English for every locale — same as before this change. Reading
+// the locale's own header would localize titles, which is worth doing but is a
+// visible change across ~70 translated pages, so it's deliberately out of scope.
+
+export function generateMetadata() {
+  return {
+    title: en.header?.title,
+    description: en.header?.description,
+  }
 }
 
-export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+export default async function GuidePage({ params }: any) {
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/account-management/page.tsx
+++ b/src/app/[locale]/guides/account-management/page.tsx
@@ -12,8 +12,8 @@ import * as en from './en.mdx'
 
 export function generateMetadata() {
   return {
-    title: en.header?.title,
-    description: en.header?.description,
+    title: en.header.title,
+    description: en.header.description,
   }
 }
 

--- a/src/app/[locale]/guides/account-management/page.tsx
+++ b/src/app/[locale]/guides/account-management/page.tsx
@@ -1,25 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Guides are translated, so the locale variant is still resolved at request
-// time. English is imported statically anyway: it's the fallback, it's the file
-// authors actually edit (so it gets a real module-graph edge for hot reload),
-// and its header supplies the metadata rather than a duplicated copy.
-//
-// Metadata stays English for every locale — same as before this change. Reading
-// the locale's own header would localize titles, which is worth doing but is a
-// visible change across ~70 translated pages, so it's deliberately out of scope.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function GuidePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/account-migration/page.tsx
+++ b/src/app/[locale]/guides/account-migration/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Account Migration',
-  description: 'How to implement account migration.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/account-migration/page.tsx
+++ b/src/app/[locale]/guides/account-migration/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/account-recovery/page.tsx
+++ b/src/app/[locale]/guides/account-recovery/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Account Recovery',
-  description: 'Self-custodying your AT Protocol identity with rotation keys.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/account-recovery/page.tsx
+++ b/src/app/[locale]/guides/account-recovery/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/auth/page.tsx
+++ b/src/app/[locale]/guides/auth/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Auth - AT Protocol Docs',
-  description: 'Auth for AT Protocol application developers.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/auth/page.tsx
+++ b/src/app/[locale]/guides/auth/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/backfilling/page.tsx
+++ b/src/app/[locale]/guides/backfilling/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/backfilling/page.tsx
+++ b/src/app/[locale]/guides/backfilling/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Backfilling - AT Protocol Docs',
-  description: 'Synchronizing and streaming data from the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/blob-lifecycle/page.tsx
+++ b/src/app/[locale]/guides/blob-lifecycle/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/blob-lifecycle/page.tsx
+++ b/src/app/[locale]/guides/blob-lifecycle/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Blob Lifecycle - AT Protocol Docs',
-  description: 'Working with image and video blobs in the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/blob-security/page.tsx
+++ b/src/app/[locale]/guides/blob-security/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/blob-security/page.tsx
+++ b/src/app/[locale]/guides/blob-security/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Blob Security - AT Protocol Docs',
-  description: 'Working with image and video blobs in the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/bot-tutorial/page.tsx
+++ b/src/app/[locale]/guides/bot-tutorial/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/bot-tutorial/page.tsx
+++ b/src/app/[locale]/guides/bot-tutorial/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Build a Social bot',
-  description: "Let's post a smiley face once every three hours.",
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/creating-a-labeler/page.tsx
+++ b/src/app/[locale]/guides/creating-a-labeler/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/creating-a-labeler/page.tsx
+++ b/src/app/[locale]/guides/creating-a-labeler/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Creating a Labeler - AT Protocol Docs',
-  description: 'Guide to moderation in AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/custom-feed-tutorial/page.tsx
+++ b/src/app/[locale]/guides/custom-feed-tutorial/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Write a Custom Feed',
-  description: "Host an algorithm that's accessible from apps like Bluesky.",
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/custom-feed-tutorial/page.tsx
+++ b/src/app/[locale]/guides/custom-feed-tutorial/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/data-repos/page.tsx
+++ b/src/app/[locale]/guides/data-repos/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Personal Data Repositories',
-  description: 'A guide to the AT Protocol repo structure.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/data-repos/page.tsx
+++ b/src/app/[locale]/guides/data-repos/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/data-validation/page.tsx
+++ b/src/app/[locale]/guides/data-validation/page.tsx
@@ -1,22 +1,19 @@
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// This page's MDX renders its own `# h1` and carries no `header`, so it takes
-// its metadata from the MDX `metadata` export and renders the content directly
-// rather than through <Page> — deliberately different from its neighbours.
-// English is imported statically so it can be the fallback and so content edits
-// hot-reload; other locales resolve per request.
+// Unlike its neighbours this page renders its MDX directly, with no <Page>
+// wrapper: the content supplies its own heading. Metadata is read from the
+// requested locale's own export — this file predates the `header` convention and
+// uses `metadata`, which mdxRouteMetadata handles. English is imported
+// statically so it can be the fallback and so content edits hot-reload.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.metadata.title,
-    description: en.metadata.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  const content = await resolveLocaleMdx(params, en, load)
   const Content = content.default
   return <Content />
 }

--- a/src/app/[locale]/guides/data-validation/page.tsx
+++ b/src/app/[locale]/guides/data-validation/page.tsx
@@ -1,14 +1,22 @@
-export const metadata = {
-  title: 'Data Validation',
-  description: 'Expectations around recommended data limits and validation.',
+import * as en from './en.mdx'
+
+// This page's MDX renders its own `# h1` and carries no `header`, so it takes
+// its metadata from the MDX `metadata` export and renders the content directly
+// rather than through <Page> — deliberately different from its neighbours.
+// English is imported statically so it can be the fallback and so content edits
+// hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.metadata.title,
+    description: en.metadata.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  try {
-    const Content = (await import(`./${(await params).locale}.mdx`)).default
-    return <Content />
-  } catch (error) {
-    const Content = (await import(`./en.mdx`)).default
-    return <Content />
-  }
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  const Content = content.default
+  return <Content />
 }

--- a/src/app/[locale]/guides/faq/page.tsx
+++ b/src/app/[locale]/guides/faq/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'FAQ',
-  description: 'Frequently Asked Questions about AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/faq/page.tsx
+++ b/src/app/[locale]/guides/faq/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/feeds/page.tsx
+++ b/src/app/[locale]/guides/feeds/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/feeds/page.tsx
+++ b/src/app/[locale]/guides/feeds/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Feeds - AT Protocol Docs',
-  description: 'Creating and consuming custom feed generators',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/glossary/page.tsx
+++ b/src/app/[locale]/guides/glossary/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/glossary/page.tsx
+++ b/src/app/[locale]/guides/glossary/page.tsx
@@ -1,17 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Glossary of terms',
-  description:
-    'A collection of terminology used in the AT Protocol and their definitions.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/go-oauth-cli-tutorial/page.tsx
+++ b/src/app/[locale]/guides/go-oauth-cli-tutorial/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/go-oauth-cli-tutorial/page.tsx
+++ b/src/app/[locale]/guides/go-oauth-cli-tutorial/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'OAuth for CLI Apps (Go)',
-  description: 'Authenticate with atproto OAuth from a Go command-line app.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/going-to-production/page.tsx
+++ b/src/app/[locale]/guides/going-to-production/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/going-to-production/page.tsx
+++ b/src/app/[locale]/guides/going-to-production/page.tsx
@@ -1,17 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Going to production',
-  description:
-    'Improve your PDS deployment.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/identity/page.tsx
+++ b/src/app/[locale]/guides/identity/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/identity/page.tsx
+++ b/src/app/[locale]/guides/identity/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Identity',
-  description: 'How the AT Protocol handles user identity.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/images-and-video/page.tsx
+++ b/src/app/[locale]/guides/images-and-video/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/images-and-video/page.tsx
+++ b/src/app/[locale]/guides/images-and-video/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Images and Video - AT Protocol Docs',
-  description: 'Working with image and video blobs in the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/installing-lexicons/page.tsx
+++ b/src/app/[locale]/guides/installing-lexicons/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Developing with Lexicons - AT Protocol Docs',
-  description: 'A schema-driven interoperability framework',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/installing-lexicons/page.tsx
+++ b/src/app/[locale]/guides/installing-lexicons/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/labels-tutorial/page.tsx
+++ b/src/app/[locale]/guides/labels-tutorial/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/labels-tutorial/page.tsx
+++ b/src/app/[locale]/guides/labels-tutorial/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Add Labels to Your App',
-  description: 'Wire a Statusphere app to an Ozone labeler service to display and create labels.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/labels/page.tsx
+++ b/src/app/[locale]/guides/labels/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Labels - AT Protocol Docs',
-  description: 'Guide to moderation in AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/labels/page.tsx
+++ b/src/app/[locale]/guides/labels/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/lexicon-style-guide/page.tsx
+++ b/src/app/[locale]/guides/lexicon-style-guide/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Lexicon Style Guide',
-  description: 'A style guide for creating new atproto schemas',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/lexicon-style-guide/page.tsx
+++ b/src/app/[locale]/guides/lexicon-style-guide/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/lexicon/page.tsx
+++ b/src/app/[locale]/guides/lexicon/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/lexicon/page.tsx
+++ b/src/app/[locale]/guides/lexicon/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Lexicons - AT Protocol Docs',
-  description: 'A schema-driven interoperability framework',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/moderation/page.tsx
+++ b/src/app/[locale]/guides/moderation/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Moderation - AT Protocol Docs',
-  description: 'Guide to moderation in AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/moderation/page.tsx
+++ b/src/app/[locale]/guides/moderation/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/oauth-cli-tutorial/page.tsx
+++ b/src/app/[locale]/guides/oauth-cli-tutorial/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/oauth-cli-tutorial/page.tsx
+++ b/src/app/[locale]/guides/oauth-cli-tutorial/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'OAuth for CLI Apps',
-  description: 'Authenticate with atproto OAuth from a command-line app.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/oauth-patterns/page.tsx
+++ b/src/app/[locale]/guides/oauth-patterns/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'OAuth Patterns - AT Protocol Docs',
-  description: 'Advanced OAuth patterns for AT Protocol applications.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/oauth-patterns/page.tsx
+++ b/src/app/[locale]/guides/oauth-patterns/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/oauth-tutorial/page.tsx
+++ b/src/app/[locale]/guides/oauth-tutorial/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/oauth-tutorial/page.tsx
+++ b/src/app/[locale]/guides/oauth-tutorial/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'OAuth with NextJS Tutorial',
-  description: 'Build a Next.js app supporting OAuth with atproto identity.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/overview/page.tsx
+++ b/src/app/[locale]/guides/overview/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Protocol Overview',
-  description: 'An introduction to the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/overview/page.tsx
+++ b/src/app/[locale]/guides/overview/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/permission-requests/page.tsx
+++ b/src/app/[locale]/guides/permission-requests/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Permission Requests - AT Protocol Docs',
-  description: 'A permissions guide for app developers and Lexicon designers',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/permission-requests/page.tsx
+++ b/src/app/[locale]/guides/permission-requests/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/permission-sets/page.tsx
+++ b/src/app/[locale]/guides/permission-sets/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/permission-sets/page.tsx
+++ b/src/app/[locale]/guides/permission-sets/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Scopes - AT Protocol Docs',
-  description: 'Auth for AT Protocol application developers.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/publishing-lexicons/page.tsx
+++ b/src/app/[locale]/guides/publishing-lexicons/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/publishing-lexicons/page.tsx
+++ b/src/app/[locale]/guides/publishing-lexicons/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Publishing Lexicons - AT Protocol Docs',
-  description: 'A schema-driven interoperability framework',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/reading-data/page.tsx
+++ b/src/app/[locale]/guides/reading-data/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Reading Data - AT Protocol Docs',
-  description: 'Read and Write AT Protocol Records.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/reading-data/page.tsx
+++ b/src/app/[locale]/guides/reading-data/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/reads-and-writes/page.tsx
+++ b/src/app/[locale]/guides/reads-and-writes/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Reads and Writes - AT Protocol Docs',
-  description: 'Read and Write AT Protocol Records.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/reads-and-writes/page.tsx
+++ b/src/app/[locale]/guides/reads-and-writes/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/scope-builder/page.tsx
+++ b/src/app/[locale]/guides/scope-builder/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Scope Builder - AT Protocol Docs',
-  description: 'Interactive tool for building OAuth scope strings and permission sets.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function ScopeBuilderPage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/scope-builder/page.tsx
+++ b/src/app/[locale]/guides/scope-builder/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function ScopeBuilderPage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/sdk-auth/page.tsx
+++ b/src/app/[locale]/guides/sdk-auth/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'SDK auth - AT Protocol Docs',
-  description: 'Auth for AT Protocol application developers.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/sdk-auth/page.tsx
+++ b/src/app/[locale]/guides/sdk-auth/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/self-hosting/page.tsx
+++ b/src/app/[locale]/guides/self-hosting/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/self-hosting/page.tsx
+++ b/src/app/[locale]/guides/self-hosting/page.tsx
@@ -1,17 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Self-hosting - AT Protocol Docs',
-  description:
-    'Self-hosting components of the AT Protocol Stack.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/social-graph/page.tsx
+++ b/src/app/[locale]/guides/social-graph/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Social Graph - AT Protocol Docs',
-  description: 'Working with AT Protocol Social Graphs',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/social-graph/page.tsx
+++ b/src/app/[locale]/guides/social-graph/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/statusphere-tutorial/page.tsx
+++ b/src/app/[locale]/guides/statusphere-tutorial/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Statusphere Example App Tutorial',
-  description: 'Build a Next.js app supporting OAuth with atproto identity.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/statusphere-tutorial/page.tsx
+++ b/src/app/[locale]/guides/statusphere-tutorial/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/streaming-data/page.tsx
+++ b/src/app/[locale]/guides/streaming-data/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Streaming Data - AT Protocol Docs',
-  description: 'Synchronizing and streaming data from the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/streaming-data/page.tsx
+++ b/src/app/[locale]/guides/streaming-data/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/subscriptions/page.tsx
+++ b/src/app/[locale]/guides/subscriptions/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/subscriptions/page.tsx
+++ b/src/app/[locale]/guides/subscriptions/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Labeler Subscriptions - AT Protocol Docs',
-  description: 'Guide to moderation in AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/sync/page.tsx
+++ b/src/app/[locale]/guides/sync/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/sync/page.tsx
+++ b/src/app/[locale]/guides/sync/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Sync - AT Protocol Docs',
-  description: 'Synchronizing and streaming data from the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/the-at-stack/page.tsx
+++ b/src/app/[locale]/guides/the-at-stack/page.tsx
@@ -1,17 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'The AT Stack - AT Protocol Docs',
-  description:
-    'Components of the AT Protocol Stack.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/the-at-stack/page.tsx
+++ b/src/app/[locale]/guides/the-at-stack/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/tutorials/page.tsx
+++ b/src/app/[locale]/guides/tutorials/page.tsx
@@ -1,17 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Tutorials - AT Protocol Docs',
-  description:
-    'These tutorials will guide you through building applications using the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/tutorials/page.tsx
+++ b/src/app/[locale]/guides/tutorials/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/understanding-atproto/page.tsx
+++ b/src/app/[locale]/guides/understanding-atproto/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/understanding-atproto/page.tsx
+++ b/src/app/[locale]/guides/understanding-atproto/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Understanding Atproto - AT Protocol Docs',
-  description: 'Dive deeper into the concepts behind the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/using-ozone/page.tsx
+++ b/src/app/[locale]/guides/using-ozone/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Using Ozone - AT Protocol Docs',
-  description: 'Guide to moderation in AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/using-ozone/page.tsx
+++ b/src/app/[locale]/guides/using-ozone/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/video-handling/page.tsx
+++ b/src/app/[locale]/guides/video-handling/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/video-handling/page.tsx
+++ b/src/app/[locale]/guides/video-handling/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Video Handling - AT Protocol Docs',
-  description: 'Working with image and video blobs in the AT Protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/guides/writing-data/page.tsx
+++ b/src/app/[locale]/guides/writing-data/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/guides/writing-data/page.tsx
+++ b/src/app/[locale]/guides/writing-data/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Writing Data - AT Protocol Docs',
-  description: 'Read and Write AT Protocol Records.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/off-protocol/2026-07-22-erin-kissane/page.tsx
+++ b/src/app/[locale]/off-protocol/2026-07-22-erin-kissane/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/2026-07-22-erin-kissane/page.tsx
+++ b/src/app/[locale]/off-protocol/2026-07-22-erin-kissane/page.tsx
@@ -1,26 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: '“Nothing Is Ever Over”',
-  description: 'Writer, speaker, and researcher Erin Kissane joins Jim to trace how the social internet got here, what’s worth salvaging, and how we can do better by listening to people.',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/2026-07-23-livestream-protocolly-atmoseed/page.tsx
+++ b/src/app/[locale]/off-protocol/2026-07-23-livestream-protocolly-atmoseed/page.tsx
@@ -1,26 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: 'Protocolly Atmoseed',
-  description: 'News from around the Atmosphere, including a proposal to fix localhost, more webdevs getting into atproto, Mu Social’s opinionated news feed, and more.',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/2026-07-23-livestream-protocolly-atmoseed/page.tsx
+++ b/src/app/[locale]/off-protocol/2026-07-23-livestream-protocolly-atmoseed/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/a-thousand-prs-in-two-weeks-building-npmx/page.tsx
+++ b/src/app/[locale]/off-protocol/a-thousand-prs-in-two-weeks-building-npmx/page.tsx
@@ -1,27 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: 'A Thousand PRs in Two Weeks: Building NPMX',
-  description:
-    'Daniel Roe, Matias Capeletto, and Zeu join to discuss how their frustration with JavaScript packaging went from a Bluesky post to one of the most successful new community-led projects on the protocol.',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/a-thousand-prs-in-two-weeks-building-npmx/page.tsx
+++ b/src/app/[locale]/off-protocol/a-thousand-prs-in-two-weeks-building-npmx/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/ama-dholms-irons-still-hot/page.tsx
+++ b/src/app/[locale]/off-protocol/ama-dholms-irons-still-hot/page.tsx
@@ -1,26 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: 'The Iron’s Still Hot',
-  description: 'Daniel Holmgren joins the livestream for an AMA on permissioned data — why it',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/ama-dholms-irons-still-hot/page.tsx
+++ b/src/app/[locale]/off-protocol/ama-dholms-irons-still-hot/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/blacksky-as-a-service-a-first-look-at-acorn/page.tsx
+++ b/src/app/[locale]/off-protocol/blacksky-as-a-service-a-first-look-at-acorn/page.tsx
@@ -1,27 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: 'Blacksky As a Service: a First Look at Acorn',
-  description:
-    "Rishi Balakrishnan joins to talk about the work that went into building Acorn, Blacksky's new platform for creating moderated communities on atproto — and why the landing page never mentions a PDS.",
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/blacksky-as-a-service-a-first-look-at-acorn/page.tsx
+++ b/src/app/[locale]/off-protocol/blacksky-as-a-service-a-first-look-at-acorn/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/cobblers-kids/page.tsx
+++ b/src/app/[locale]/off-protocol/cobblers-kids/page.tsx
@@ -1,26 +1,27 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: 'The Cobbler’s Kids',
-  description: 'Jim and Alex are back on the livestream at a new time to discuss personal websites, Coop 1.0, exciting announcements from Eurosky, a new OAuth scope builder—plus news from around the Atmosphere.',
+// Episodes aren't translated, so en.mdx is imported statically: it gives the
+// route a real module-graph edge (content edits hot-reload) and its header
+// supplies the metadata rather than a duplicate copy that can drift from it.
+// transcript.mdx is always scaffolded alongside en.mdx, so it's a static import
+// too — a stub with no real transcript renders nothing, and EpisodePage only
+// shows the section when the header sets hasTranscript.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/cobblers-kids/page.tsx
+++ b/src/app/[locale]/off-protocol/cobblers-kids/page.tsx
@@ -1,19 +1,14 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
-// Episodes aren't translated, so en.mdx is imported statically: it gives the
-// route a real module-graph edge (content edits hot-reload) and its header
-// supplies the metadata rather than a duplicate copy that can drift from it.
-// transcript.mdx is always scaffolded alongside en.mdx, so it's a static import
-// too — a stub with no real transcript renders nothing, and EpisodePage only
-// shows the section when the header sets hasTranscript.
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/do-this-together-standard-site/page.tsx
+++ b/src/app/[locale]/off-protocol/do-this-together-standard-site/page.tsx
@@ -1,26 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: 'Why Don’t We Just Do This Together?',
-  description: 'Jim sits down with members of the core team building and governing Standard.site, the shared Lexicon for publishing longform writing on atproto. Brooke from pckt.blog, Jared from Leaflet, and Miguel from Offprint cover the design tradeoffs in creating a new shared format, tales of data migrations, strategies for shared governance, and why you shouldn’t buy a premium domain name.',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/do-this-together-standard-site/page.tsx
+++ b/src/app/[locale]/off-protocol/do-this-together-standard-site/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/in-our-timeline/page.tsx
+++ b/src/app/[locale]/off-protocol/in-our-timeline/page.tsx
@@ -1,26 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: 'In Our Timeline',
-  description: 'Paul and Daniel are on the livestream this week with a look at the new Standard.site integration, updates from permissioned data, and news from around the Atmosphere',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/in-our-timeline/page.tsx
+++ b/src/app/[locale]/off-protocol/in-our-timeline/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/network-in-your-hand/page.tsx
+++ b/src/app/[locale]/off-protocol/network-in-your-hand/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/network-in-your-hand/page.tsx
+++ b/src/app/[locale]/off-protocol/network-in-your-hand/page.tsx
@@ -1,26 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: 'Sometimes You Just Want to Hold the Entire Network in Your Hand',
-  description: 'Jim and Alex are back on the livestream. The permissioned data proposal has shipped, updates from Tangled, Roomy, and Anisota, and a look ahead at Jetstream v2.',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/roost-v1-juliet-shen/page.tsx
+++ b/src/app/[locale]/off-protocol/roost-v1-juliet-shen/page.tsx
@@ -1,26 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: '“Policy Without Tools Is Just Poetry”',
-  description: 'Juliet Shen from ROOST joins the show to talk through the Coop 1.0 release, what open-source trust and safety unlocks for new builders, and where AI actually belongs in moderation',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/roost-v1-juliet-shen/page.tsx
+++ b/src/app/[locale]/off-protocol/roost-v1-juliet-shen/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/slowly-then-quickly-what-atmosphereconf-made-visible/page.tsx
+++ b/src/app/[locale]/off-protocol/slowly-then-quickly-what-atmosphereconf-made-visible/page.tsx
@@ -1,27 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: 'Slowly, Then Quickly: What AtmosphereConf Made Visible',
-  description:
-    'With AtmosphereConf 2026 wrapped, Boris Mann and Ted Han join to talk about what the gathering surfaced in the ecosystem. From the IETF working group, the move beyond a single foundation, to a growing layer of co-ops, regional meetups, and independent stewards.',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/slowly-then-quickly-what-atmosphereconf-made-visible/page.tsx
+++ b/src/app/[locale]/off-protocol/slowly-then-quickly-what-atmosphereconf-made-visible/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/the-puppy-problem/page.tsx
+++ b/src/app/[locale]/off-protocol/the-puppy-problem/page.tsx
@@ -1,27 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: 'The Puppy Problem',
-  description:
-    'Jim and Alex are live with the first live episode under the new Off Protocol name. Protocol meetups are happening everywhere, Alex and Jim were both in Portland, the Ozone moderation tool has some new features, and Bluesky is considering an edit button. Plus a few of your questions.',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/the-puppy-problem/page.tsx
+++ b/src/app/[locale]/off-protocol/the-puppy-problem/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/off-protocol/why-a-new-protocol-the-history-and-future-of-at-protocol/page.tsx
+++ b/src/app/[locale]/off-protocol/why-a-new-protocol-the-history-and-future-of-at-protocol/page.tsx
@@ -1,27 +1,24 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: 'Why a New Protocol? The History and Future of AT Protocol',
-  description:
-    "Bluesky CTO Paul Frazee and Head of Protocol Daniel Holmgren join for a wide-ranging conversation about what atproto is, why it exists, how it got built, and where it's going next. From a Twitter consultancy to an IETF working group, this is where to get started.",
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(`./${(await params).locale}.mdx`).catch(
-    () => import(`./en.mdx`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(`./transcript.mdx`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }

--- a/src/app/[locale]/off-protocol/why-a-new-protocol-the-history-and-future-of-at-protocol/page.tsx
+++ b/src/app/[locale]/off-protocol/why-a-new-protocol-the-history-and-future-of-at-protocol/page.tsx
@@ -1,4 +1,5 @@
 import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -7,10 +8,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/app/[locale]/specs/account/page.tsx
+++ b/src/app/[locale]/specs/account/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Accounts',
-  description: 'Account Hosting and Lifecycle',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/account/page.tsx
+++ b/src/app/[locale]/specs/account/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/at-uri-scheme/page.tsx
+++ b/src/app/[locale]/specs/at-uri-scheme/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'AT URI scheme (at://)',
-  description: 'A URI scheme for addressing ATP repository data.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/at-uri-scheme/page.tsx
+++ b/src/app/[locale]/specs/at-uri-scheme/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/atp/page.tsx
+++ b/src/app/[locale]/specs/atp/page.tsx
@@ -1,17 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'AT Protocol',
-  description:
-    'Specification for the Authenticated Transfer Protocol (AT Protocol)',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/atp/page.tsx
+++ b/src/app/[locale]/specs/atp/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/blob/page.tsx
+++ b/src/app/[locale]/specs/blob/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/blob/page.tsx
+++ b/src/app/[locale]/specs/blob/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Blobs',
-  description: 'Media files referenced by records',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/cryptography/page.tsx
+++ b/src/app/[locale]/specs/cryptography/page.tsx
@@ -1,17 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Cryptography',
-  description:
-    'Cryptographic systems, curves, and key types used in AT Protocol',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/cryptography/page.tsx
+++ b/src/app/[locale]/specs/cryptography/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/data-model/page.tsx
+++ b/src/app/[locale]/specs/data-model/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/data-model/page.tsx
+++ b/src/app/[locale]/specs/data-model/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Data Model',
-  description: 'Consistent data encoding for records and messages.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/did/page.tsx
+++ b/src/app/[locale]/specs/did/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'DID',
-  description: 'Persistent decentralized identifiers (as used in atproto)',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/did/page.tsx
+++ b/src/app/[locale]/specs/did/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/event-stream/page.tsx
+++ b/src/app/[locale]/specs/event-stream/page.tsx
@@ -1,18 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Event Stream',
-  description:
-    'Network wire protocol for subscribing to a stream of Lexicon objects',
-  wip: true,
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/event-stream/page.tsx
+++ b/src/app/[locale]/specs/event-stream/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/handle/page.tsx
+++ b/src/app/[locale]/specs/handle/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Handle',
-  description: 'A specification for human-friendly account identifiers.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/handle/page.tsx
+++ b/src/app/[locale]/specs/handle/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/label/page.tsx
+++ b/src/app/[locale]/specs/label/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/label/page.tsx
+++ b/src/app/[locale]/specs/label/page.tsx
@@ -1,17 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Labels',
-  description:
-    'Self-authenticating string annotations on accounts or content for moderation and other purposes.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/lexicon/page.tsx
+++ b/src/app/[locale]/specs/lexicon/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Lexicon',
-  description: 'A schema definition language.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/lexicon/page.tsx
+++ b/src/app/[locale]/specs/lexicon/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/nsid/page.tsx
+++ b/src/app/[locale]/specs/nsid/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/nsid/page.tsx
+++ b/src/app/[locale]/specs/nsid/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Namespaced Identifiers (NSIDs)',
-  description: 'A specification for global semantic IDs.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/oauth/page.tsx
+++ b/src/app/[locale]/specs/oauth/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/oauth/page.tsx
+++ b/src/app/[locale]/specs/oauth/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'OAuth',
-  description: 'OAuth for Client/Server Authentication and Authorization',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/permission/page.tsx
+++ b/src/app/[locale]/specs/permission/page.tsx
@@ -1,22 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// This page's MDX carries `metadata` rather than a `header`, so it supplies the
-// route metadata from there. <Page> still receives the whole module, and with no
-// `header` prop it renders no PageHeader — the MDX provides its own heading,
-// which is the existing behaviour. English is imported statically so it can be
-// the fallback and so content edits hot-reload.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.metadata.title,
-    description: en.metadata.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/permission/page.tsx
+++ b/src/app/[locale]/specs/permission/page.tsx
@@ -1,16 +1,22 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Permissions',
-  description: 'Auth Permissions for Account Resources',
+// This page's MDX carries `metadata` rather than a `header`, so it supplies the
+// route metadata from there. <Page> still receives the whole module, and with no
+// `header` prop it renders no PageHeader — the MDX provides its own heading,
+// which is the existing behaviour. English is imported statically so it can be
+// the fallback and so content edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: en.metadata.title,
+    description: en.metadata.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/record-key/page.tsx
+++ b/src/app/[locale]/specs/record-key/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/record-key/page.tsx
+++ b/src/app/[locale]/specs/record-key/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Record Key',
-  description: 'Identifier for individual records in a collection',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/repository/page.tsx
+++ b/src/app/[locale]/specs/repository/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Repository',
-  description: 'Self-authenticating storage for public account content',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/repository/page.tsx
+++ b/src/app/[locale]/specs/repository/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/sync/page.tsx
+++ b/src/app/[locale]/specs/sync/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/sync/page.tsx
+++ b/src/app/[locale]/specs/sync/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Sync',
-  description: 'Firehose and other data synchronization mechanisms.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/tid/page.tsx
+++ b/src/app/[locale]/specs/tid/page.tsx
@@ -1,17 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'Timestamp Identifiers (TIDs)',
-  description:
-    'A compact timestamp-based identifier for revisions and records.',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/tid/page.tsx
+++ b/src/app/[locale]/specs/tid/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/app/[locale]/specs/xrpc/page.tsx
+++ b/src/app/[locale]/specs/xrpc/page.tsx
@@ -1,16 +1,20 @@
 import { Page } from '@/components/Page'
+import * as en from './en.mdx'
 
-export const metadata = {
-  title: 'HTTP API (XRPC)',
-  description: 'Cross-system queries and procedures over HTTP',
+// Metadata comes from the MDX header (see mdx.d.ts), in English for every
+// locale as before. English is imported statically so it can be the fallback
+// and so content edits hot-reload; other locales resolve per request.
+
+export function generateMetadata() {
+  return {
+    title: en.header.title,
+    description: en.header.description,
+  }
 }
 
 export default async function HomePage({ params }: any) {
-  let Content
-  try {
-    Content = await import(`./${(await params).locale}.mdx`)
-  } catch (error) {
-    Content = await import(`./en.mdx`)
-  }
-  return <Page {...Content} />
+  const { locale } = await params
+  const content =
+    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
+  return <Page {...content} />
 }

--- a/src/app/[locale]/specs/xrpc/page.tsx
+++ b/src/app/[locale]/specs/xrpc/page.tsx
@@ -1,20 +1,16 @@
 import { Page } from '@/components/Page'
+import { mdxRouteMetadata, resolveLocaleMdx } from '@/lib/localizedMdx'
 import * as en from './en.mdx'
 
-// Metadata comes from the MDX header (see mdx.d.ts), in English for every
-// locale as before. English is imported statically so it can be the fallback
-// and so content edits hot-reload; other locales resolve per request.
+// Metadata is read from the requested locale's own header, so a translated page
+// gets a translated <title>. English is imported statically so it can be the
+// fallback and so content edits hot-reload; other locales resolve per request.
+const load = (locale: string) => import(`./${locale}.mdx`)
 
-export function generateMetadata() {
-  return {
-    title: en.header.title,
-    description: en.header.description,
-  }
+export async function generateMetadata({ params }: any) {
+  return mdxRouteMetadata(await resolveLocaleMdx(params, en, load))
 }
 
 export default async function HomePage({ params }: any) {
-  const { locale } = await params
-  const content =
-    locale === 'en' ? en : await import(`./${locale}.mdx`).catch(() => en)
-  return <Page {...content} />
+  return <Page {...(await resolveLocaleMdx(params, en, load))} />
 }

--- a/src/lib/localizedMdx.test.ts
+++ b/src/lib/localizedMdx.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { resolveLocaleMdx, mdxRouteMetadata } from './localizedMdx'
+
+const en = { header: { title: 'English', description: 'En desc' } }
+const ja = { header: { title: '日本語', description: 'Ja desc' } }
+
+describe('resolveLocaleMdx', () => {
+  it('short-circuits for English without invoking the loader', async () => {
+    let called = false
+    const out = await resolveLocaleMdx(Promise.resolve({ locale: 'en' }), en, async () => {
+      called = true
+      return ja
+    })
+    expect(out).toBe(en)
+    expect(called).toBe(false)
+  })
+
+  it('loads the requested locale', async () => {
+    const seen: string[] = []
+    const out = await resolveLocaleMdx(Promise.resolve({ locale: 'ja' }), en, async (l) => {
+      seen.push(l)
+      return ja
+    })
+    expect(seen).toEqual(['ja'])
+    expect(out).toBe(ja)
+  })
+
+  it('falls back to English when the translation is missing', async () => {
+    // Not every page is translated into every language; a missing file must
+    // render English rather than 500.
+    const out = await resolveLocaleMdx(Promise.resolve({ locale: 'pt' }), en, async () => {
+      throw new Error('ENOENT')
+    })
+    expect(out).toBe(en)
+  })
+
+  it('falls back when no locale is present at all', async () => {
+    let called = false
+    const out = await resolveLocaleMdx(Promise.resolve({}), en, async () => {
+      called = true
+      return ja
+    })
+    expect(out).toBe(en)
+    expect(called).toBe(false)
+  })
+})
+
+describe('mdxRouteMetadata', () => {
+  it('reads the header export', () => {
+    expect(mdxRouteMetadata(ja)).toEqual({ title: '日本語', description: 'Ja desc' })
+  })
+
+  it('falls back to the older metadata export', () => {
+    // Two pages predate the header convention — see mdx.d.ts.
+    const mod = { metadata: { title: 'Data Validation', description: 'Limits' } }
+    expect(mdxRouteMetadata(mod)).toEqual({
+      title: 'Data Validation',
+      description: 'Limits',
+    })
+  })
+
+  it('prefers header when a file carries both', () => {
+    const mod = {
+      header: { title: 'From header', description: 'H' },
+      metadata: { title: 'From metadata', description: 'M' },
+    }
+    expect(mdxRouteMetadata(mod)).toEqual({ title: 'From header', description: 'H' })
+  })
+
+  it('returns undefined fields rather than throwing when neither exists', () => {
+    expect(mdxRouteMetadata({})).toEqual({ title: undefined, description: undefined })
+  })
+})

--- a/src/lib/localizedMdx.ts
+++ b/src/lib/localizedMdx.ts
@@ -1,0 +1,52 @@
+/**
+ * Helpers shared by every content `page.tsx`.
+ *
+ * These exist so the locale-fallback rule and the header/metadata lookup are
+ * defined and tested once, rather than regenerated into ~130 route files where a
+ * subtle difference between copies would go unnoticed. The dynamic `import()`
+ * itself has to stay in the page — webpack resolves it relative to that file —
+ * so it's passed in as a loader.
+ */
+
+type MdxModule = { header?: unknown; metadata?: unknown }
+
+/**
+ * Resolve the MDX module for the requested locale, falling back to English.
+ *
+ * English short-circuits: it's already imported statically by the caller, which
+ * is what gives the route a real module-graph edge for hot reload. A locale with
+ * no translated file falls back rather than failing — coverage is partial by
+ * design (ja/ko/pt, not every page).
+ */
+export async function resolveLocaleMdx<T extends MdxModule>(
+  params: Promise<{ locale?: string }> | { locale?: string },
+  en: T,
+  load: (locale: string) => Promise<T>,
+): Promise<T> {
+  const { locale } = await params
+  if (!locale || locale === 'en') return en
+  try {
+    return await load(locale)
+  } catch {
+    return en
+  }
+}
+
+/**
+ * The title and description a route should report, read from the MDX module.
+ *
+ * Prefers `header`, the convention nearly every file uses, and falls back to the
+ * older `metadata` export that a couple of pages still carry (see mdx.d.ts).
+ * Returns undefined fields rather than throwing: a content file with neither is
+ * a bug worth surfacing as a missing title, not a 500.
+ */
+export function mdxRouteMetadata(mod: MdxModule): {
+  title: string | undefined
+  description: string | undefined
+} {
+  const source = (mod.header ?? mod.metadata ?? {}) as {
+    title?: string
+    description?: string
+  }
+  return { title: source.title, description: source.description }
+}

--- a/src/lib/studio/episodeService.test.ts
+++ b/src/lib/studio/episodeService.test.ts
@@ -94,7 +94,7 @@ describe('createEpisode', () => {
     expect(Number.isNaN(new Date(fields.pubDate).getTime())).toBe(false)
   })
 
-  it('smartens the title and description in all three files it writes', async () => {
+  it('smartens the title and description everywhere it stores them', async () => {
     await createEpisode(
       paths,
       baseInput({
@@ -104,16 +104,27 @@ describe('createEpisode', () => {
     )
     const dir = path.join(paths.podcastDir, 'my-ep')
     const mdx = fs.readFileSync(path.join(dir, 'en.mdx'), 'utf-8')
-    const page = fs.readFileSync(path.join(dir, 'page.tsx'), 'utf-8')
     const eps = fs.readFileSync(paths.episodesFile, 'utf-8')
     for (const [label, content] of [
       ['en.mdx', mdx],
-      ['page.tsx', page],
       ['episodes.ts', eps],
     ] as const) {
       expect(content, label).toContain('“Nothing Is Ever Over”')
       expect(content, label).toContain('What’s next — a lot, it turns out…')
     }
+  })
+
+  it('does not write the title into page.tsx at all', async () => {
+    // page.tsx reads the MDX header, so it must not become a third copy — that
+    // duplication is what drifted before, leaving stale titles in OG previews.
+    await createEpisode(paths, baseInput({ title: 'Distinctive Title' }))
+    const page = fs.readFileSync(
+      path.join(paths.podcastDir, 'my-ep', 'page.tsx'),
+      'utf-8',
+    )
+    expect(page).not.toContain('Distinctive Title')
+    expect(page).not.toContain('export const metadata')
+    expect(page).toContain('notes.header.title')
   })
 
   it('rejects a duplicate slug', async () => {

--- a/src/lib/studio/episodeService.test.ts
+++ b/src/lib/studio/episodeService.test.ts
@@ -124,7 +124,7 @@ describe('createEpisode', () => {
     )
     expect(page).not.toContain('Distinctive Title')
     expect(page).not.toContain('export const metadata')
-    expect(page).toContain('notes.header.title')
+    expect(page).toContain('mdxRouteMetadata(notes)')
   })
 
   it('rejects a duplicate slug', async () => {

--- a/src/lib/studio/episodeService.ts
+++ b/src/lib/studio/episodeService.ts
@@ -46,31 +46,36 @@ export type CreateEpisodeInput = {
 const TRANSCRIPT_STUB =
   '{/* Paste the episode transcript here, then flip hasTranscript: true in en.mdx. */}\n'
 
-function pageTsx(title: string, description: string): string {
-  const q = (v: string) => v.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
+/**
+ * The `page.tsx` written alongside a new episode.
+ *
+ * Takes no arguments: the route reads its title and description from the MDX
+ * header, so nothing is interpolated and nothing can drift from the content.
+ * en.mdx and transcript.mdx are static imports — episodes aren't translated, and
+ * the module edge is what lets show-notes edits hot-reload.
+ */
+function pageTsx(): string {
   return `import { EpisodePage } from '@/components/EpisodePage'
+import * as notes from './en.mdx'
+import * as transcript from './transcript.mdx'
 
-export const metadata = {
-  title: '${q(title)}',
-  description: '${q(description)}',
+// Metadata comes from the MDX header (see mdx.d.ts). Episodes aren't
+// translated, so en.mdx and transcript.mdx are static imports — which is also
+// what makes show-notes edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: notes.header.title,
+    description: notes.header.description,
+  }
 }
 
-export default async function EpisodeRoute({ params }: any) {
-  const Notes = await import(\`./\${(await params).locale}.mdx\`).catch(
-    () => import(\`./en.mdx\`),
-  )
-  let Transcript = null
-  try {
-    Transcript = await import(\`./transcript.mdx\`)
-  } catch {
-    // optional
-  }
-
+export default function EpisodeRoute() {
   return (
     <EpisodePage
-      default={Notes.default}
-      header={Notes.header}
-      Transcript={Transcript?.default}
+      default={notes.default}
+      header={notes.header}
+      Transcript={transcript.default}
     />
   )
 }
@@ -140,9 +145,9 @@ export async function createEpisode(
   paths: EpisodePaths,
   rawInput: CreateEpisodeInput,
 ): Promise<{ slug: string }> {
-  // Smarten once, up front: page.tsx metadata is written from `input` while the
-  // MDX header and episodes.ts entry come from `fields`, so transforming here is
-  // what keeps all three copies identical.
+  // Smarten before anything derives from these values, so the MDX header and the
+  // episodes.ts entry agree. (page.tsx used to be a third copy; it now reads the
+  // header, so there's one fewer place to keep in step.)
   const input = smartenTitleAndDescription(rawInput)
   for (const f of ['slug', 'title', 'description', 'date'] as const) {
     if (!input[f] || !String(input[f]).trim()) throw new Error(`Field "${f}" is required`)
@@ -175,7 +180,7 @@ export async function createEpisode(
 
   await fs.mkdir(dir, { recursive: true })
   try {
-    await fs.writeFile(path.join(dir, 'page.tsx'), pageTsx(input.title, input.description))
+    await fs.writeFile(path.join(dir, 'page.tsx'), pageTsx())
     await fs.writeFile(path.join(dir, 'en.mdx'), newEpisodeMdx(fields, body))
     await fs.writeFile(path.join(dir, 'transcript.mdx'), TRANSCRIPT_STUB)
     await fs.writeFile(paths.episodesFile, nextSrc)

--- a/src/lib/studio/episodeService.ts
+++ b/src/lib/studio/episodeService.ts
@@ -56,6 +56,7 @@ const TRANSCRIPT_STUB =
  */
 function pageTsx(): string {
   return `import { EpisodePage } from '@/components/EpisodePage'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as notes from './en.mdx'
 import * as transcript from './transcript.mdx'
 
@@ -64,10 +65,7 @@ import * as transcript from './transcript.mdx'
 // what makes show-notes edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: notes.header.title,
-    description: notes.header.description,
-  }
+  return mdxRouteMetadata(notes)
 }
 
 export default function EpisodeRoute() {

--- a/src/lib/studio/service.test.ts
+++ b/src/lib/studio/service.test.ts
@@ -78,7 +78,7 @@ describe('smart typography', () => {
     const page = fs.readFileSync(path.join(paths.blogDir, 'hello', 'page.tsx'), 'utf-8')
     expect(page).not.toContain('Distinctive Title')
     expect(page).not.toContain('export const metadata')
-    expect(page).toContain('content.header.title')
+    expect(page).toContain('mdxRouteMetadata(content)')
   })
 
   it('returns the smartened fields so the editor can show what was stored', async () => {

--- a/src/lib/studio/service.test.ts
+++ b/src/lib/studio/service.test.ts
@@ -44,7 +44,7 @@ afterEach(() => {
 })
 
 describe('smart typography', () => {
-  it('smartens title and description in all three files createPost writes', async () => {
+  it('smartens title and description everywhere createPost stores them', async () => {
     await createPost(paths, {
       slug: 'hello',
       title: '"Quoted" Title',
@@ -56,13 +56,29 @@ describe('smart typography', () => {
     const dir = path.join(paths.blogDir, 'hello')
     for (const [label, file] of [
       ['en.mdx', path.join(dir, 'en.mdx')],
-      ['page.tsx', path.join(dir, 'page.tsx')],
       ['posts.ts', paths.postsFile],
     ] as const) {
       const content = fs.readFileSync(file, 'utf-8')
       expect(content, label).toContain('“Quoted” Title')
       expect(content, label).toContain('What’s next — a lot…')
     }
+  })
+
+  it('does not write the title into page.tsx at all', async () => {
+    // page.tsx reads the MDX header, so it must not become a third copy — that
+    // duplication is what drifted before, leaving stale titles in OG previews.
+    await createPost(paths, {
+      slug: 'hello',
+      title: 'Distinctive Title',
+      description: 'Desc',
+      date: 'June 1, 2026',
+      author: 'Jim Ray',
+      body: 'Body.\n',
+    })
+    const page = fs.readFileSync(path.join(paths.blogDir, 'hello', 'page.tsx'), 'utf-8')
+    expect(page).not.toContain('Distinctive Title')
+    expect(page).not.toContain('export const metadata')
+    expect(page).toContain('content.header.title')
   })
 
   it('returns the smartened fields so the editor can show what was stored', async () => {

--- a/src/lib/studio/service.ts
+++ b/src/lib/studio/service.ts
@@ -211,7 +211,7 @@ export async function createPost(
   const nextPostsSrc = prependEntry(postsSrc, entryFor(input.slug, owned))
 
   await fs.mkdir(dir, { recursive: true })
-  await fs.writeFile(path.join(dir, 'page.tsx'), blogPageTsx(owned))
+  await fs.writeFile(path.join(dir, 'page.tsx'), blogPageTsx())
   await fs.writeFile(path.join(dir, 'en.mdx'), newPostMdx(owned, body))
   await fs.writeFile(paths.postsFile, nextPostsSrc)
 

--- a/src/lib/studio/templates.test.ts
+++ b/src/lib/studio/templates.test.ts
@@ -7,8 +7,8 @@ describe('blogPageTsx', () => {
     expect(out).toContain("import { Page } from '@/components/Page'")
     expect(out).toContain("import * as content from './en.mdx'")
     expect(out).toContain('export function generateMetadata()')
-    expect(out).toContain('content.header.title')
-    expect(out).toContain('content.header.description')
+    expect(out).toContain("from '@/lib/localizedMdx'")
+    expect(out).toContain('mdxRouteMetadata(content)')
     expect(out).toContain('export default function BlogPost')
   })
 

--- a/src/lib/studio/templates.test.ts
+++ b/src/lib/studio/templates.test.ts
@@ -2,11 +2,21 @@ import { describe, it, expect } from 'vitest'
 import { blogPageTsx } from './templates'
 
 describe('blogPageTsx', () => {
-  it('emits a Page component with escaped metadata', () => {
-    const out = blogPageTsx({ title: "It's Here", description: 'Desc' })
+  it('derives metadata from the MDX header instead of duplicating it', () => {
+    const out = blogPageTsx()
     expect(out).toContain("import { Page } from '@/components/Page'")
-    expect(out).toContain("title: 'It\\'s Here'")
-    expect(out).toContain("description: 'Desc'")
-    expect(out).toContain('export default async function BlogPost')
+    expect(out).toContain("import * as content from './en.mdx'")
+    expect(out).toContain('export function generateMetadata()')
+    expect(out).toContain('content.header.title')
+    expect(out).toContain('content.header.description')
+    expect(out).toContain('export default function BlogPost')
+  })
+
+  it('emits no metadata object and no dynamic import', () => {
+    // The duplicated object was the thing that drifted from the header, and the
+    // template-literal import was what defeated hot reload.
+    const out = blogPageTsx()
+    expect(out).not.toContain('export const metadata')
+    expect(out).not.toContain('${')
   })
 })

--- a/src/lib/studio/templates.ts
+++ b/src/lib/studio/templates.ts
@@ -8,6 +8,7 @@
  */
 export function blogPageTsx(): string {
   return `import { Page } from '@/components/Page'
+import { mdxRouteMetadata } from '@/lib/localizedMdx'
 import * as content from './en.mdx'
 
 // Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
@@ -15,10 +16,7 @@ import * as content from './en.mdx'
 // edits hot-reload.
 
 export function generateMetadata() {
-  return {
-    title: content.header.title,
-    description: content.header.description,
-  }
+  return mdxRouteMetadata(content)
 }
 
 export default function BlogPost() {

--- a/src/lib/studio/templates.ts
+++ b/src/lib/studio/templates.ts
@@ -1,26 +1,28 @@
-function q(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")
-}
-
-export function blogPageTsx(input: {
-  title: string
-  description: string
-}): string {
+/**
+ * The `page.tsx` written alongside a new blog post.
+ *
+ * Takes no arguments: the route reads its title and description from the MDX
+ * header, so there's nothing to interpolate and nothing that can drift from the
+ * content. en.mdx is imported statically — blog posts aren't translated, and the
+ * module edge is what lets a content edit hot-reload.
+ */
+export function blogPageTsx(): string {
   return `import { Page } from '@/components/Page'
+import * as content from './en.mdx'
 
-export const metadata = {
-  title: '${q(input.title)}',
-  description: '${q(input.description)}',
+// Metadata comes from the MDX header (see mdx.d.ts). en.mdx is imported
+// statically — not translated, and the module edge is what makes content
+// edits hot-reload.
+
+export function generateMetadata() {
+  return {
+    title: content.header.title,
+    description: content.header.description,
+  }
 }
 
-export default async function BlogPost({ params }: any) {
-  let Content
-  try {
-    Content = await import(\`./\${(await params).locale}.mdx\`)
-  } catch (error) {
-    Content = await import(\`./en.mdx\`)
-  }
-  return <Page {...Content} />
+export default function BlogPost() {
+  return <Page {...content} />
 }
 `
 }


### PR DESCRIPTION
There was some duplicated page metadata that was getting increasingly hard to track down, especially on the blog and podcast changes. This aims to fix that, which involved touching most pages on the site.

Content routes were deriving their `<title>` and description from a metadata object in the `page.tsx` file, duplicating what was already in the MDX header with nothing to keep the data in sync. 

This also broke hot reloading of the site and metadata for localized pages, both of which should be fixed now.

While this is a big PR, most of the changes are generated output. This is mostly a quality of life improvement, not critical to the site, so if it feels to risky, no big deal.

144 files changed, but only two commits contain decisions. The other two are generated
output and can be skimmed:

| Commit | What |
| --- | --- |
| `derive route metadata from the MDX header` | **Read this.** Templates, generators, `mdx.d.ts`. |
| `codemod 128 content pages…` | Generated. |
| `localize route metadata` | **Read this.** `src/lib/localizedMdx.ts` + tests. |
| `codemod 131 pages…` | Generated. |

A survey grouped all 131 content pages by structure first, so each codemod only
rewrote shapes that actually existed (115 `<Page>`, 12 `<EpisodePage>`) and
skipped anything else rather than guessing. `guides/data-validation` was skipped
both times and converted by hand: it renders its MDX directly, and the standard
template would have wrapped it in `<Page>`, adding a PageHeader it deliberately
lacks.

## Verified

Against a running dev server, not just in CI:

- A body edit and a header edit each landed on the **first** request afterwards,
  with no restart. Both previously required one. Re-checked after the
  localisation commit, since that template has two dynamic-import sites.
- Titles per locale: `/ja/guides/account-management` → アカウント管理,
  `/ko/specs/repository` → 레포지토리, `/pt/articles/…` → Portuguese.
- `/pt/guides/account-management`, which has no `pt` translation → 200 in
  English, not a 500.
- Untranslated areas under a locale prefix (`/ja/blog/…`, `/ja/off-protocol/…`)
  → 200, English, as before.
- Both pages using the older `metadata` export convention.

Before generating anything, checked that all 129 header-carrying pages have both
a title and a description — so no generated `generateMetadata()` can throw — and
that every episode has the `transcript.mdx` its static import needs.

219 unit tests, 18 script tests, `tsc` clean.

## Decisions 

**`header` is typed `any` in `mdx.d.ts`.** I tried a structural type and it
doesn't work: `EpisodePage` requires `episodeNumber`, `date`, `pubDate`, and
`audioUrl`, and no index signature or optional-property type satisfies required
props — TS wanted a double cast in all 13 episode pages, which asserts exactly as
much as `any` while looking more rigorous. Not a regression (the dynamic import
already resolved to `any`, which is why nothing surfaced the missing types
before), and header shape is enforced where headers are *written*, in
`src/lib/studio`, under test. But it is weaker than I'd like.

**The generators changed too.** `blogPageTsx()` and the episode `pageTsx()` now
take no arguments, and both create CLIs emit the new shape — otherwise the next
post or episode would reintroduce the duplication. Their tests assert the title
is *absent* from `page.tsx`, which locks that in.

**Locale resolution lives in a shared helper**, not in the templates:
`src/lib/localizedMdx.ts`. Localised metadata means resolving the locale twice
per page, and generating that logic into 131 files would have meant 262 untested
copies of a fallback rule. The dynamic `import()` stays in each page, since
webpack resolves it relative to that file.

- **feat(pages): prototype metadata derived from the MDX header**
- **refactor(pages): derive route metadata from the MDX header**
- **refactor(pages): codemod 128 content pages to header-derived metadata**
- **feat(pages): localize route metadata**
- **refactor(pages): codemod 131 pages onto the localized metadata helpers**
