### PR TITLE
Studio: create a new branch as part of the creation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,19 @@ Each editor has a switch to the other in its sidebar.
   Automatic *generation* is not implemented for either editor.
 - **No body preview.** Use the **Open ↗** link in the action bar to see the real
   page.
-- **No git operations.** Branch, stage, and commit in your normal flow.
+- **Creating offers a branch.** The create form shows the branch it will make
+  from `origin/main`, with an editable name and the exact commands it will run.
+  Defaults match the names already in use: `blog-<slug>` for posts,
+  `off-protocol-<YYYY-MM-DD>` for episodes. Untick it to create on the current
+  branch instead. Editing existing content never branches — the action bar just
+  shows which branch you're on, so it isn't silent.
+- **A dirty working tree blocks branching, not authoring.** Any output from
+  `git status --porcelain` counts, untracked files included: a stray file would
+  travel to the new branch and could land in the PR. The form lists what's dirty
+  and still lets you create where you are. Nothing is written when a branch is
+  requested and refused — the refusal is complete, not partial.
+- **Nothing else is a git operation.** Staging, committing, and pushing stay in
+  your normal flow.
 - **Smart typography on save.** Titles and descriptions are stored with curly
   quotes, em/en dashes, and ellipses, matching what the prose pipeline does to
   MDX bodies at render time. Those two fields are plain JS strings in
@@ -584,7 +596,18 @@ The site hosts the *Off Protocol* podcast at `/off-protocol`. Episodes follow th
 npm run podcast create
 ```
 
-Prompts for title, slug, episode number, description, audio URL, guests, and an optional Bluesky discussion link. The script HEADs the audio URL (failing if unreachable) and probes its duration via `ffprobe` if installed (falling back to a manual prompt). It scaffolds:
+Refuses to run on a dirty working tree, then offers to create a branch from
+`origin/main` — the same step, and the same implementation (`src/lib/git.mjs`),
+as the [Dev Studio](#dev-studio-dev-only). The CLIs refuse outright on a dirty
+tree rather than offering to continue, which is reasonable for a command you
+invoke deliberately.
+
+Prompts for title, guests, slug, episode number, description, audio URL, and an
+optional Bluesky discussion link. Guests come before the slug so the suggested
+slug can include the guest: episodes default to
+`YYYY-MM-DD-title[-first-guest]`, matching the show's existing slugs. The script
+HEADs the audio URL (failing if unreachable) and probes its duration via
+`ffprobe` if installed (falling back to a manual prompt). It scaffolds:
 
 - `src/app/[locale]/off-protocol/<slug>/page.tsx`
 - `src/app/[locale]/off-protocol/<slug>/en.mdx` (show notes)

--- a/scripts/new-blog-post.mjs
+++ b/scripts/new-blog-post.mjs
@@ -8,6 +8,8 @@ import { fileURLToPath } from 'url'
 import { parseCreateArgs } from './lib/parseCreateArgs.mjs'
 import { createPublishFn } from './lib/createPublishFn.mjs'
 import { smartText } from '../src/mdx/smartText.mjs'
+import { gitState, createBranch, branchNameFor } from '../src/lib/git.mjs'
+import { slugify } from '../src/lib/slugs.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const BLOG_DIR = path.join(__dirname, '../src/app/[locale]/blog')
@@ -26,13 +28,6 @@ function question(prompt) {
   })
 }
 
-function slugify(text) {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-}
-
 function formatDate(date) {
   return date.toLocaleDateString('en-US', {
     month: 'long',
@@ -42,33 +37,38 @@ function formatDate(date) {
 }
 
 async function checkGitStatus() {
+  let state
   try {
-    const status = execSync('git status --porcelain', { encoding: 'utf-8' }).trim()
-    if (status) {
-      const branch = execSync('git branch --show-current', { encoding: 'utf-8' }).trim()
-      console.error(`⚠️ You have uncommitted changes on ${branch}. Please commit or stash your work and then get back to blogging.`)
-      process.exit(1)
-    }
+    state = await gitState()
   } catch {
     console.error('Error: Failed to check git status. Are you in a git repository?')
     process.exit(1)
   }
-
+  if (state.dirty) {
+    console.error(
+      `⚠️ You have uncommitted changes on ${state.branch}. Please commit or stash your work and then get back to blogging.`,
+    )
+    process.exit(1)
+  }
   const answer = await question('Create a new branch from origin/main? (Y/n): ')
   return answer.trim().toLowerCase() !== 'n'
 }
 
-function createBranch(slug) {
-  const branch = `blog-${slug}`
+// Prompts for the branch name, defaulting to the same `blog-<slug>` the studio
+// suggests, then creates it from origin/main. Shares one implementation with the
+// studio so the two tools can't drift.
+async function makeBranch(slug) {
+  const suggested = branchNameFor('blog', { slug })
+  const answer = (await question(`Branch name (${suggested}): `)).trim()
+  const name = answer || suggested
+  console.log(`\nFetching origin/main and creating ${name}...`)
   try {
-    console.log(`\nFetching latest from origin/main...`)
-    execSync('git fetch origin main', { encoding: 'utf-8', stdio: 'inherit' })
-    console.log(`Creating branch ${branch} from origin/main...`)
-    execSync(`git checkout -b ${branch} origin/main`, { encoding: 'utf-8', stdio: 'inherit' })
-  } catch {
-    console.error(`Error: Failed to create branch "${branch}". Does it already exist?`)
+    await createBranch(name)
+  } catch (err) {
+    console.error(`Error: ${err.message}`)
     process.exit(1)
   }
+  return name
 }
 
 export async function main(...args) {
@@ -122,8 +122,9 @@ export async function main(...args) {
 
   rl.close()
 
+  let branchName
   if (shouldCreateBranch) {
-    createBranch(slug)
+    branchName = await makeBranch(slug)
   }
 
   // Create directory
@@ -195,7 +196,7 @@ Start writing your post here...
 Files created:
   - src/app/[locale]/blog/${slug}/page.tsx
   - src/app/[locale]/blog/${slug}/en.mdx
-${shouldCreateBranch ? `\nBranch: blog-${slug} (from origin/main)` : ''}
+${branchName ? `\nBranch: ${branchName} (from origin/main)` : ''}
 Next steps:
   1. Edit src/app/[locale]/blog/${slug}/en.mdx to write your post
   2. Run 'npm run dev' to preview at http://localhost:3000/blog/${slug}

--- a/scripts/new-episode.mjs
+++ b/scripts/new-episode.mjs
@@ -7,6 +7,8 @@ import * as path from 'path'
 import { execSync } from 'child_process'
 import { fileURLToPath } from 'url'
 import { smartText } from '../src/mdx/smartText.mjs'
+import { gitState, createBranch, branchNameFor } from '../src/lib/git.mjs'
+import { episodeSlug } from '../src/lib/slugs.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const PODCAST_DIR = path.join(__dirname, '../src/app/[locale]/off-protocol')
@@ -27,13 +29,6 @@ function question(prompt) {
   return new Promise((resolve) => {
     rl.question(prompt, resolve)
   })
-}
-
-function slugify(text) {
-  return text
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
 }
 
 function formatDate(date) {
@@ -87,23 +82,38 @@ function probeDuration(url) {
 }
 
 async function checkGitStatus() {
+  let state
   try {
-    const status = execSync('git status --porcelain', {
-      encoding: 'utf-8',
-    }).trim()
-    if (status) {
-      const branch = execSync('git branch --show-current', {
-        encoding: 'utf-8',
-      }).trim()
-      console.error(
-        `⚠️ You have uncommitted changes on ${branch}. Please commit or stash before continuing.`,
-      )
-      process.exit(1)
-    }
+    state = await gitState()
   } catch {
     console.error('Error: Failed to check git status. Are you in a git repository?')
     process.exit(1)
   }
+  if (state.dirty) {
+    console.error(
+      `⚠️ You have uncommitted changes on ${state.branch}. Please commit or stash before continuing.`,
+    )
+    process.exit(1)
+  }
+  const answer = await question('Create a new branch from origin/main? (Y/n): ')
+  return answer.trim().toLowerCase() !== 'n'
+}
+
+// Prompts for the branch name, defaulting to the same off-protocol-<date> the
+// studio suggests, then creates it from origin/main. Shares one implementation
+// with the studio so the two tools can't drift.
+async function makeBranch(pubDate, slug) {
+  const suggested = branchNameFor('podcast', { pubDate, slug })
+  const answer = (await question(`Branch name (${suggested}): `)).trim()
+  const name = answer || suggested
+  console.log(`\nFetching origin/main and creating ${name}...`)
+  try {
+    await createBranch(name)
+  } catch (err) {
+    console.error(`Error: ${err.message}`)
+    process.exit(1)
+  }
+  return name
 }
 
 function nextEpisodeNumber() {
@@ -116,7 +126,7 @@ function nextEpisodeNumber() {
 export async function main() {
   console.log('\n🎙️  Create a new Off Protocol episode\n')
 
-  await checkGitStatus()
+  const shouldCreateBranch = await checkGitStatus()
 
   // Fail fast if the anchor we insert against isn't where we expect it,
   // rather than running the user through every prompt and then writing
@@ -134,13 +144,24 @@ export async function main() {
     process.exit(1)
   }
 
+  // Stamped up front: the slug suggestion and the branch name both need it.
+  const now = new Date()
+  const date = formatDate(now)
+  const pubDate = now.toISOString()
+
   const title = smartText((await question('Title: ')).trim())
   if (!title) {
     console.error('Error: Title is required')
     process.exit(1)
   }
 
-  const suggestedSlug = slugify(title)
+  const guestsInput = (await question('Guests (comma-separated, optional): ')).trim()
+  const guests = guestsInput
+    ? guestsInput.split(',').map((s) => s.trim()).filter(Boolean)
+    : []
+
+  // YYYY-MM-DD-title[-first-guest], the same default the studio offers.
+  const suggestedSlug = episodeSlug({ pubDate, title, guests })
   const slugInput = (await question(`Slug (${suggestedSlug}): `)).trim()
   const slug = slugInput || suggestedSlug
 
@@ -196,18 +217,14 @@ export async function main() {
   const duration = formatHHMMSS(durationSeconds)
   console.log(`  Duration: ${duration} (${durationSeconds}s)`)
 
-  const guestsInput = (await question('Guests (comma-separated, optional): ')).trim()
-  const guests = guestsInput
-    ? guestsInput.split(',').map((s) => s.trim()).filter(Boolean)
-    : []
-
   const blueskyPostUrl = (
     await question('Bluesky discussion post URL (optional): ')
   ).trim()
 
-  const now = new Date()
-  const date = formatDate(now)
-  const pubDate = now.toISOString()
+  let branchName
+  if (shouldCreateBranch) {
+    branchName = await makeBranch(pubDate, slug)
+  }
 
   rl.close()
 
@@ -319,7 +336,7 @@ ${blueskyPostUrl ? `    blueskyPostUrl: '${blueskyPostUrl.replace(/'/g, "\\'")}'
   fs.writeFileSync(EPISODES_FILE, updated)
 
   console.log(`
-✅ Episode created!
+✅ Episode created!${branchName ? `\n\nBranch: ${branchName} (from origin/main)` : ''}
 
 Files:
   - src/app/[locale]/off-protocol/${slug}/page.tsx

--- a/src/app/[locale]/guides/creating-a-labeler/en.mdx
+++ b/src/app/[locale]/guides/creating-a-labeler/en.mdx
@@ -27,6 +27,8 @@ Labeler service records created before support was added for new [`knownValues` 
 
 You can update the record manually as you would [any other record](/guides/writing-data#updating-records). Alternatively, you can delete the `reasonType` field from your record entirely, which will cause your labeler to accept all report reason types, including any added in the future.
 
+You can find a community-contributed guide to updating your Labeler service record on [Leaflet](https://leaflet.pub/da19b6c7-5695-473a-849b-3d6eb2398e68).
+
 ## Ozone
 
 [Ozone](https://github.com/bluesky-social/ozone) is our reference labeling service for Atmosphere apps, and includes a web interface for triaging and actioning moderation reports.

--- a/src/app/[locale]/guides/creating-a-labeler/en.mdx
+++ b/src/app/[locale]/guides/creating-a-labeler/en.mdx
@@ -27,7 +27,7 @@ Labeler service records created before support was added for new [`knownValues` 
 
 You can update the record manually as you would [any other record](/guides/writing-data#updating-records). Alternatively, you can delete the `reasonType` field from your record entirely, which will cause your labeler to accept all report reason types, including any added in the future.
 
-You can find a community-contributed guide to updating your Labeler service record on [Leaflet](https://leaflet.pub/da19b6c7-5695-473a-849b-3d6eb2398e68).
+You can find a community-contributed guide to updating your Labeler service record on [Leaflet](https://leaflet.pub/p/did:plc:uzdfxwdzkggwc4652mdecmsg/3mrq4g7ish224).
 
 ## Ozone
 

--- a/src/app/api/studio/blog/route.ts
+++ b/src/app/api/studio/blog/route.ts
@@ -1,5 +1,6 @@
 import { isProd, studioPaths } from '@/lib/studio/paths'
 import { listPosts, createPost, publishPost } from '@/lib/studio/service'
+import { gitState, createBranch } from '@/lib/studio/git'
 
 export const runtime = 'nodejs'
 
@@ -15,14 +16,45 @@ export async function GET() {
 
 export async function POST(request: Request) {
   if (isProd()) return notFound()
+  // Declared outside the try so a later failure can still report that a branch
+  // was created — the author needs to know which branch they are now on.
+  let branch: { created: true; name: string } | undefined
   try {
     const paths = studioPaths()
     const input = await request.json()
+    const requested = input.branch as { name?: string } | undefined
+
+    if (requested?.name) {
+      // Re-check rather than trusting the form's snapshot: files may have
+      // changed since it was opened.
+      const state = await gitState()
+      if (state.dirty) {
+        return Response.json(
+          {
+            error: `Working tree has uncommitted changes (${state.files.length} file(s)). Commit or stash them, or create without a branch.`,
+            files: state.files,
+          },
+          { status: 409 },
+        )
+      }
+      await createBranch(requested.name)
+      branch = { created: true, name: requested.name }
+    }
+
     const result = await createPost(paths, input)
     // Auto-publish the standard.site record on create (non-blocking).
     const publish = await publishPost(paths, result.slug)
-    return Response.json({ ...result, publish }, { status: 201 })
+    return Response.json({ ...result, publish, branch }, { status: 201 })
   } catch (err) {
-    return Response.json({ error: (err as Error).message }, { status: 400 })
+    const message = (err as Error).message
+    return Response.json(
+      {
+        error: branch
+          ? `${message} — you are now on branch ${branch.name}`
+          : message,
+        branch,
+      },
+      { status: 400 },
+    )
   }
 }

--- a/src/app/api/studio/git/route.ts
+++ b/src/app/api/studio/git/route.ts
@@ -1,0 +1,15 @@
+import { isProd } from '@/lib/studio/paths'
+import { gitState } from '@/lib/studio/git'
+
+export const runtime = 'nodejs'
+
+// Read-only: reports the branch and working-tree state so the studio can show
+// where a create would land before writing anything.
+export async function GET() {
+  if (isProd()) return new Response('Not found', { status: 404 })
+  try {
+    return Response.json(await gitState())
+  } catch (err) {
+    return Response.json({ error: (err as Error).message }, { status: 400 })
+  }
+}

--- a/src/app/api/studio/podcast/route.ts
+++ b/src/app/api/studio/podcast/route.ts
@@ -1,6 +1,7 @@
 import { isProd } from '@/lib/studio/paths'
 import { episodePaths } from '@/lib/studio/paths'
 import { listEpisodes, createEpisode, nextEpisodeNumber } from '@/lib/studio/episodeService'
+import { gitState, createBranch } from '@/lib/studio/git'
 
 export const runtime = 'nodejs'
 
@@ -20,11 +21,42 @@ export async function GET() {
 
 export async function POST(request: Request) {
   if (isProd()) return notFound()
+  // Declared outside the try so a later failure can still report that a branch
+  // was created — the author needs to know which branch they are now on.
+  let branch: { created: true; name: string } | undefined
   try {
     const input = await request.json()
+    const requested = input.branch as { name?: string } | undefined
+
+    if (requested?.name) {
+      // Re-check rather than trusting the form's snapshot: files may have
+      // changed since it was opened.
+      const state = await gitState()
+      if (state.dirty) {
+        return Response.json(
+          {
+            error: `Working tree has uncommitted changes (${state.files.length} file(s)). Commit or stash them, or create without a branch.`,
+            files: state.files,
+          },
+          { status: 409 },
+        )
+      }
+      await createBranch(requested.name)
+      branch = { created: true, name: requested.name }
+    }
+
     const result = await createEpisode(episodePaths(), input)
-    return Response.json(result, { status: 201 })
+    return Response.json({ ...result, branch }, { status: 201 })
   } catch (err) {
-    return Response.json({ error: (err as Error).message }, { status: 400 })
+    const message = (err as Error).message
+    return Response.json(
+      {
+        error: branch
+          ? `${message} — you are now on branch ${branch.name}`
+          : message,
+        branch,
+      },
+      { status: 400 },
+    )
   }
 }

--- a/src/app/studio/blog/BlogEditor.tsx
+++ b/src/app/studio/blog/BlogEditor.tsx
@@ -1,6 +1,10 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+// Pure module, and a type-only import that TypeScript erases: this is a client
+// component, so nothing reaching node:child_process may be imported here.
+import { branchNameFor } from '@/lib/gitNames.mjs'
+import type { GitState } from '@/lib/studio/git'
 import { StudioNav } from '../StudioNav'
 
 type PostListItem = { slug: string; title: string; date: string }
@@ -37,6 +41,10 @@ export function BlogEditor() {
   const [dragging, setDragging] = useState(false)
   const [status, setStatus] = useState<string>('')
   const [copied, setCopied] = useState(false)
+  const [git, setGit] = useState<GitState | null>(null)
+  const [makeBranch, setMakeBranch] = useState(true)
+  const [branchName, setBranchName] = useState('')
+  const [dirtyFiles, setDirtyFiles] = useState<string[]>([])
 
   async function refreshList() {
     try {
@@ -49,8 +57,29 @@ export function BlogEditor() {
     }
   }
 
+  // Derived rather than stored so it keeps tracking the title as it's typed;
+  // an edit to the field wins from then on. Declared above save(), which reads it.
+  const derivedBranch =
+    branchName || branchNameFor('blog', { slug: slug || slugify(owned.title) })
+
+  async function loadGit() {
+    try {
+      const res = await fetch('/api/studio/git')
+      if (!res.ok) return setGit(null)
+      const data: GitState = await res.json()
+      setGit(data)
+      setDirtyFiles(data.files)
+      // A dirty tree can't be branched from; creating here stays available.
+      if (data.dirty) setMakeBranch(false)
+      return data
+    } catch {
+      setGit(null)
+    }
+  }
+
   useEffect(() => {
     refreshList()
+    loadGit()
   }, [])
 
   function startNew() {
@@ -63,6 +92,9 @@ export function BlogEditor() {
     setOgImage(null)
     setDragging(false)
     setStatus('')
+    setBranchName('')
+    setMakeBranch(true)
+    loadGit()
   }
 
   async function loadPost(s: string) {
@@ -98,15 +130,31 @@ export function BlogEditor() {
       const res = await fetch('/api/studio/blog', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ slug: finalSlug, ...owned, authorDid: authorDid || undefined, body }),
+        body: JSON.stringify({
+          slug: finalSlug,
+          ...owned,
+          authorDid: authorDid || undefined,
+          body,
+          branch: makeBranch && derivedBranch ? { name: derivedBranch } : undefined,
+        }),
       })
       const data = await res.json()
+      if (res.status === 409) {
+        // Dirty tree: nothing was branched and nothing was written. Untick the
+        // box so a retry creates here instead.
+        setDirtyFiles(data.files ?? [])
+        setMakeBranch(false)
+        await loadGit()
+        return setStatus(`Error: ${data.error}`)
+      }
       if (!res.ok) return setStatus(`Error: ${data.error}`)
       // Reveal step 2: load the created post (body placeholder, ssite, og image)
       // from disk, then show a plain save status.
       await loadPost(data.slug)
       applyPublish(data.publish)
-      setStatus(`Created ${data.slug}`)
+      const where = data.branch?.created ? ` on ${data.branch.name}` : ''
+      setStatus(data.warning ?? `Created ${data.slug}${where}`)
+      await loadGit()
       await refreshList()
     } else {
       setStatus('Saving…')
@@ -260,6 +308,11 @@ export function BlogEditor() {
                 /blog/{slug} ↗
               </a>
             )}
+            {git && (
+              <span className="font-mono text-xs text-neutral-400">
+                on {git.branch}
+              </span>
+            )}
           </div>
           <div className="flex items-center gap-4">
             {status && (
@@ -345,6 +398,59 @@ export function BlogEditor() {
               </Field>
             )}
           </div>
+
+          {mode === 'new' && (
+            <div className="mt-6 border-t border-neutral-200 pt-6">
+              <p className="mb-1.5 block text-[0.7rem] font-medium uppercase tracking-[0.18em] text-neutral-400">
+                Branch
+              </p>
+              {git?.dirty ? (
+                <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-neutral-700">
+                  <p>
+                    Can’t branch: {dirtyFiles.length} uncommitted change
+                    {dirtyFiles.length === 1 ? '' : 's'} on{' '}
+                    <span className="font-mono">{git.branch}</span>. Commit or stash
+                    them to branch, or create here anyway.
+                  </p>
+                  <ul className="mt-1 font-mono text-xs text-neutral-500">
+                    {dirtyFiles.slice(0, 5).map((f) => (
+                      <li key={f}>{f}</li>
+                    ))}
+                    {dirtyFiles.length > 5 && <li>…and {dirtyFiles.length - 5} more</li>}
+                  </ul>
+                </div>
+              ) : (
+                <>
+                  <label className="flex items-center gap-2 text-sm text-neutral-700">
+                    <input
+                      type="checkbox"
+                      checked={makeBranch}
+                      onChange={(e) => setMakeBranch(e.target.checked)}
+                    />
+                    Create a branch from origin/main
+                  </label>
+                  {makeBranch && (
+                    <>
+                      <input
+                        value={derivedBranch}
+                        onChange={(e) => setBranchName(e.target.value)}
+                        className="mt-2 w-full rounded-md border border-neutral-300 bg-white px-3 py-1.5 font-mono text-sm outline-none focus:border-neutral-500"
+                      />
+                      <pre className="mt-2 overflow-x-auto rounded bg-neutral-50 px-3 py-2 font-mono text-xs text-neutral-500">
+                        git fetch origin main{'\n'}git checkout -b {derivedBranch} origin/main
+                      </pre>
+                    </>
+                  )}
+                  {git && (
+                    <p className="mt-2 text-xs text-neutral-500">
+                      Currently on <span className="font-mono">{git.branch}</span> ·
+                      working tree clean
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+          )}
 
           {mode === 'new' && (
             <div className="mt-6 flex flex-col items-end gap-2 border-t border-neutral-200 pt-6">

--- a/src/app/studio/podcast/EpisodeEditor.tsx
+++ b/src/app/studio/podcast/EpisodeEditor.tsx
@@ -9,6 +9,7 @@ import {
 // Pure module, and a type-only import that TypeScript erases: this is a client
 // component, so nothing reaching node:child_process may be imported here.
 import { branchNameFor } from '@/lib/gitNames.mjs'
+import { episodeSlug } from '@/lib/slugs.mjs'
 import type { GitState } from '@/lib/studio/git'
 import { StudioNav } from '../StudioNav'
 
@@ -34,9 +35,6 @@ type Fields = {
   blueskyPostUrl: string
 }
 
-function slugify(t: string): string {
-  return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
-}
 function fmtDuration(totalSeconds: number): string {
   const s = Math.round(totalSeconds)
   const hh = String(Math.floor(s / 3600)).padStart(2, '0')
@@ -86,6 +84,11 @@ export function EpisodeEditor() {
   const [makeBranch, setMakeBranch] = useState(true)
   const [branchName, setBranchName] = useState('')
   const [dirtyFiles, setDirtyFiles] = useState<string[]>([])
+  // The comma-separated fields keep their own raw text. Deriving the input's
+  // value from the parsed array re-rendered a trimmed string on every
+  // keystroke, so a space could never survive being typed.
+  const [hostsText, setHostsText] = useState('')
+  const [guestsText, setGuestsText] = useState('')
 
   async function refreshList() {
     try {
@@ -99,6 +102,18 @@ export function EpisodeEditor() {
       setStatus('Could not load the episode list')
     }
   }
+
+  // Split on commas but preserve what was typed inside each name.
+  const parseNames = (text: string) =>
+    text.split(',').map((n) => n.trim()).filter(Boolean)
+
+  // YYYY-MM-DD-title[-first-guest], matching the show's existing slugs. Derived
+  // so it tracks the title, guests, and publish date as they're edited.
+  const defaultSlug = episodeSlug({
+    pubDate: fields.pubDate,
+    title: fields.title,
+    guests: fields.guests,
+  })
 
   async function loadGit() {
     try {
@@ -130,6 +145,8 @@ export function EpisodeEditor() {
     setSlug('')
     const dates = nowDates()
     setFields({ ...emptyFields(nextNumber), ...dates })
+    setHostsText('')
+    setGuestsText('')
     setBody('')
     setOgImage(null)
     setStatus('')
@@ -145,6 +162,8 @@ export function EpisodeEditor() {
     setMode('edit')
     setSlug(s)
     setFields(data.fields)
+    setHostsText((data.fields.hosts ?? []).join(', '))
+    setGuestsText((data.fields.guests ?? []).join(', '))
     setBody(data.body)
     setOgImage(data.ogImage ?? null)
     setOgVersion((v) => v + 1)
@@ -218,7 +237,7 @@ export function EpisodeEditor() {
 
   async function save() {
     if (mode === 'new') {
-      const finalSlug = slug || slugify(fields.title)
+      const finalSlug = slug || defaultSlug
       if (!finalSlug) return setStatus('Add a title or slug first')
       setStatus('Creating…')
       const res = await fetch('/api/studio/podcast', {
@@ -379,10 +398,31 @@ export function EpisodeEditor() {
               <input value={fields.date} onChange={(e) => setF('date', e.target.value)} className={input} />
               <span className="mt-1 block text-xs italic text-neutral-400">Follows the publish date; edit for custom wording.</span>
             </div>
-            <div><span className={label}>Hosts (comma-sep)</span><input value={fields.hosts.join(', ')} onChange={(e) => setF('hosts', e.target.value.split(',').map((s) => s.trim()).filter(Boolean))} placeholder="Jim Ray (show default)" className={input} /></div>
-            <div><span className={label}>Guests (comma-sep)</span><input value={fields.guests.join(', ')} onChange={(e) => setF('guests', e.target.value.split(',').map((s) => s.trim()).filter(Boolean))} className={input} /></div>
+            <div>
+              <span className={label}>Hosts (comma-sep)</span>
+              <input
+                value={hostsText}
+                onChange={(e) => {
+                  setHostsText(e.target.value)
+                  setF('hosts', parseNames(e.target.value))
+                }}
+                placeholder="Jim Ray (show default)"
+                className={input}
+              />
+            </div>
+            <div>
+              <span className={label}>Guests (comma-sep)</span>
+              <input
+                value={guestsText}
+                onChange={(e) => {
+                  setGuestsText(e.target.value)
+                  setF('guests', parseNames(e.target.value))
+                }}
+                className={input}
+              />
+            </div>
             {mode === 'new' ? (
-              <div><span className={label}>Slug (blank = from title)</span><input value={slug} onChange={(e) => setSlug(e.target.value)} placeholder={slugify(fields.title) || 'my-episode'} className={input + ' font-mono'} /></div>
+              <div><span className={label}>Slug (blank = from title)</span><input value={slug} onChange={(e) => setSlug(e.target.value)} placeholder={defaultSlug || 'my-episode'} className={input + ' font-mono'} /></div>
             ) : (
               <div><span className={label}>Slug (read-only)</span><div className="rounded-md border border-neutral-200 bg-neutral-50 px-3 py-1.5 font-mono text-sm text-neutral-500">{slug}</div></div>
             )}

--- a/src/app/studio/podcast/EpisodeEditor.tsx
+++ b/src/app/studio/podcast/EpisodeEditor.tsx
@@ -6,6 +6,10 @@ import {
   localInputToIso,
   isoToHumanDate,
 } from '@/lib/studio/episodeDates'
+// Pure module, and a type-only import that TypeScript erases: this is a client
+// component, so nothing reaching node:child_process may be imported here.
+import { branchNameFor } from '@/lib/gitNames.mjs'
+import type { GitState } from '@/lib/studio/git'
 import { StudioNav } from '../StudioNav'
 
 type ListItem = { slug: string; title: string; episodeNumber: number }
@@ -78,6 +82,10 @@ export function EpisodeEditor() {
   const [ogImage, setOgImage] = useState<string | null>(null)
   const [ogVersion, setOgVersion] = useState(0)
   const [status, setStatus] = useState('')
+  const [git, setGit] = useState<GitState | null>(null)
+  const [makeBranch, setMakeBranch] = useState(true)
+  const [branchName, setBranchName] = useState('')
+  const [dirtyFiles, setDirtyFiles] = useState<string[]>([])
 
   async function refreshList() {
     try {
@@ -92,8 +100,26 @@ export function EpisodeEditor() {
     }
   }
 
+  async function loadGit() {
+    try {
+      const res = await fetch('/api/studio/git')
+      if (!res.ok) return setGit(null)
+      const data: GitState = await res.json()
+      setGit(data)
+      setDirtyFiles(data.files)
+      // A dirty tree can't be branched from; creating here stays available.
+      if (data.dirty) setMakeBranch(false)
+      return data
+    } catch {
+      setGit(null)
+    }
+  }
+
   useEffect(() => {
-    setFields((f) => ({ ...f, ...nowDates() }))
+    const dates = nowDates()
+    setFields((f) => ({ ...f, ...dates }))
+    setBranchName(branchNameFor('podcast', { pubDate: dates.pubDate }))
+    loadGit()
     refreshList().then((n) => {
       if (typeof n === 'number') setFields((f) => ({ ...f, episodeNumber: n }))
     })
@@ -102,10 +128,14 @@ export function EpisodeEditor() {
   function startNew() {
     setMode('new')
     setSlug('')
-    setFields({ ...emptyFields(nextNumber), ...nowDates() })
+    const dates = nowDates()
+    setFields({ ...emptyFields(nextNumber), ...dates })
     setBody('')
     setOgImage(null)
     setStatus('')
+    setBranchName(branchNameFor('podcast', { pubDate: dates.pubDate }))
+    setMakeBranch(true)
+    loadGit()
   }
 
   async function loadEpisode(s: string) {
@@ -210,12 +240,26 @@ export function EpisodeEditor() {
           explicit: fields.explicit,
           blueskyPostUrl: fields.blueskyPostUrl,
           body,
+          branch: makeBranch && branchName ? { name: branchName } : undefined,
         }),
       })
       const data = await res.json()
+      if (res.status === 409) {
+        // Dirty tree: nothing was branched and nothing was written. Untick the
+        // box so a retry creates here instead.
+        setDirtyFiles(data.files ?? [])
+        setMakeBranch(false)
+        await loadGit()
+        return setStatus(`Error: ${data.error}`)
+      }
       if (!res.ok) return setStatus(`Error: ${data.error}`)
       await loadEpisode(data.slug)
-      setStatus(`Created ${data.slug}`)
+      setStatus(
+        data.branch?.created
+          ? `Created ${data.slug} on ${data.branch.name}`
+          : `Created ${data.slug}`,
+      )
+      await loadGit()
       await refreshList()
     } else {
       setStatus('Saving…')
@@ -307,6 +351,9 @@ export function EpisodeEditor() {
                 /off-protocol/{slug} ↗
               </a>
             )}
+            {git && (
+              <span className="font-mono text-xs text-neutral-400">on {git.branch}</span>
+            )}
           </div>
           <div className="flex items-center gap-4">
             {status && <span className={'text-sm ' + (isError ? 'text-red-600' : 'text-neutral-500')} aria-live="polite">{status}</span>}
@@ -343,6 +390,57 @@ export function EpisodeEditor() {
               <input type="checkbox" checked={fields.explicit} onChange={(e) => setF('explicit', e.target.checked)} /> Explicit
             </label>
           </div>
+
+          {mode === 'new' && (
+            <div className="mt-6 border-t border-neutral-200 pt-6">
+              <p className={label}>Branch</p>
+              {git?.dirty ? (
+                <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-neutral-700">
+                  <p>
+                    Can’t branch: {dirtyFiles.length} uncommitted change
+                    {dirtyFiles.length === 1 ? '' : 's'} on{' '}
+                    <span className="font-mono">{git.branch}</span>. Commit or stash
+                    them to branch, or create here anyway.
+                  </p>
+                  <ul className="mt-1 font-mono text-xs text-neutral-500">
+                    {dirtyFiles.slice(0, 5).map((f) => (
+                      <li key={f}>{f}</li>
+                    ))}
+                    {dirtyFiles.length > 5 && <li>…and {dirtyFiles.length - 5} more</li>}
+                  </ul>
+                </div>
+              ) : (
+                <>
+                  <label className="flex items-center gap-2 text-sm text-neutral-700">
+                    <input
+                      type="checkbox"
+                      checked={makeBranch}
+                      onChange={(e) => setMakeBranch(e.target.checked)}
+                    />
+                    Create a branch from origin/main
+                  </label>
+                  {makeBranch && (
+                    <>
+                      <input
+                        value={branchName}
+                        onChange={(e) => setBranchName(e.target.value)}
+                        className={input + ' mt-2 font-mono'}
+                      />
+                      <pre className="mt-2 overflow-x-auto rounded bg-neutral-50 px-3 py-2 font-mono text-xs text-neutral-500">
+                        git fetch origin main{'\n'}git checkout -b {branchName} origin/main
+                      </pre>
+                    </>
+                  )}
+                  {git && (
+                    <p className="mt-2 text-xs text-neutral-500">
+                      Currently on <span className="font-mono">{git.branch}</span> ·
+                      working tree clean
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+          )}
 
           {mode === 'new' && (
             <div className="mt-6 flex flex-col items-end gap-2 border-t border-neutral-200 pt-6">

--- a/src/lib/git.mjs
+++ b/src/lib/git.mjs
@@ -1,0 +1,84 @@
+/**
+ * Git helpers shared by the studio API routes and the authoring CLIs.
+ *
+ * Plain JavaScript on purpose: the `.mjs` scripts in scripts/ cannot cleanly
+ * import a `.ts` module, so this is the one implementation and
+ * src/lib/studio/git.ts re-exports it with types. Same arrangement as
+ * src/mdx/smartText.mjs.
+ */
+
+/**
+ * `YYYY-MM-DD` in local time, or '' when unparseable.
+ *
+ * Duplicates isoToDateStamp in src/lib/studio/episodeDates.ts, which is
+ * TypeScript and therefore not importable here. Five lines is a better trade
+ * than restructuring tested code to cross the language boundary.
+ *
+ * @param {string} iso
+ * @returns {string}
+ */
+function dateStamp(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+/**
+ * Parse `git status --porcelain` output.
+ *
+ * Any output at all means dirty, untracked files included: a stray file travels
+ * to the new branch and can end up in the post's PR.
+ *
+ * @param {string} porcelain
+ * @returns {{ dirty: boolean, files: string[] }}
+ */
+export function parseGitStatus(porcelain) {
+  const files = []
+  for (const raw of String(porcelain).split('\n')) {
+    if (!raw.trim()) continue
+    // Porcelain v1: two status characters, a space, then the path.
+    const path = raw.slice(3)
+    // Renames read `old -> new`; report the destination.
+    const arrow = path.indexOf(' -> ')
+    files.push(arrow === -1 ? path : path.slice(arrow + 4))
+  }
+  return { dirty: files.length > 0, files }
+}
+
+/**
+ * The default branch name for new content, matching names already in use in
+ * this repo: `blog-<slug>` and `off-protocol-<YYYY-MM-DD>`.
+ *
+ * @param {'blog' | 'podcast'} kind
+ * @param {{ slug?: string, pubDate?: string }} [opts]
+ * @returns {string}
+ */
+export function branchNameFor(kind, opts = {}) {
+  const { slug = '', pubDate = '' } = opts
+  if (kind === 'podcast') {
+    const stamp = dateStamp(pubDate)
+    return stamp ? `off-protocol-${stamp}` : `off-protocol-${slug}`
+  }
+  return `blog-${slug}`
+}
+
+/**
+ * Whether a string is safe to pass to `git checkout -b`.
+ *
+ * The name comes from a browser form. It is also passed via execFile with an
+ * argv array, so this is defence in depth rather than the only guard.
+ *
+ * @param {unknown} name
+ * @returns {boolean}
+ */
+export function isValidBranchName(name) {
+  if (typeof name !== 'string' || name === '') return false
+  if (/\s/.test(name)) return false
+  if (/[~^:?*[\\]/.test(name)) return false
+  if (name.includes('..') || name.includes('@{')) return false
+  if (/^[-/.]/.test(name)) return false
+  if (/[/.]$/.test(name) || name.endsWith('.lock')) return false
+  return true
+}

--- a/src/lib/git.mjs
+++ b/src/lib/git.mjs
@@ -6,6 +6,10 @@
  * src/lib/studio/git.ts re-exports it with types. Same arrangement as
  * src/mdx/smartText.mjs.
  */
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
 
 /**
  * `YYYY-MM-DD` in local time, or '' when unparseable.
@@ -81,4 +85,69 @@ export function isValidBranchName(name) {
   if (/^[-/.]/.test(name)) return false
   if (/[/.]$/.test(name) || name.endsWith('.lock')) return false
   return true
+}
+
+/**
+ * Default runner: execFile with an argv array, never a shell.
+ *
+ * @param {string} command
+ * @param {string[]} args
+ * @returns {Promise<string>}
+ */
+async function defaultRun(command, args) {
+  const { stdout } = await execFileAsync(command, args)
+  return stdout
+}
+
+/**
+ * Run one git command, raising an error that carries git's own message.
+ *
+ * @param {(command: string, args: string[]) => Promise<string>} run
+ * @param {string[]} args
+ * @returns {Promise<string>}
+ */
+async function git(run, args) {
+  try {
+    return await run('git', args)
+  } catch (err) {
+    const detail = String(err?.stderr || err?.message || '')
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .pop()
+    throw new Error(`git ${args.join(' ')} failed: ${detail || 'unknown error'}`)
+  }
+}
+
+/**
+ * Current branch, and whether the working tree has uncommitted changes.
+ *
+ * @param {{ run?: (command: string, args: string[]) => Promise<string> }} [opts]
+ * @returns {Promise<{ branch: string, dirty: boolean, files: string[] }>}
+ */
+export async function gitState(opts = {}) {
+  const run = opts.run ?? defaultRun
+  const branch = (await git(run, ['branch', '--show-current'])).trim()
+  const porcelain = await git(run, ['status', '--porcelain'])
+  return { branch, ...parseGitStatus(porcelain) }
+}
+
+/**
+ * Create `name` from `origin/main`, fetching first.
+ *
+ * Refuses invalid names before running anything. A failed fetch aborts rather
+ * than branching from a possibly stale local ref.
+ *
+ * @param {string} name
+ * @param {{ run?: (command: string, args: string[]) => Promise<string> }} [opts]
+ * @returns {Promise<{ name: string }>}
+ */
+export async function createBranch(name, opts = {}) {
+  const run = opts.run ?? defaultRun
+  if (!isValidBranchName(name)) {
+    throw new Error(`Invalid branch name: ${JSON.stringify(name)}`)
+  }
+  await git(run, ['fetch', 'origin', 'main'])
+  await git(run, ['checkout', '-b', name, 'origin/main'])
+  return { name }
 }

--- a/src/lib/git.mjs
+++ b/src/lib/git.mjs
@@ -1,91 +1,26 @@
 /**
- * Git helpers shared by the studio API routes and the authoring CLIs.
+ * Git operations for the studio API routes and the authoring CLIs.
  *
  * Plain JavaScript on purpose: the `.mjs` scripts in scripts/ cannot cleanly
  * import a `.ts` module, so this is the one implementation and
  * src/lib/studio/git.ts re-exports it with types. Same arrangement as
  * src/mdx/smartText.mjs.
+ *
+ * SERVER-SIDE ONLY — this imports node:child_process. Client components must
+ * import the pure helpers from ./gitNames.mjs instead; see the note there.
  */
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
+import {
+  parseGitStatus,
+  branchNameFor,
+  isValidBranchName,
+} from './gitNames.mjs'
+
+// Re-exported so server-side callers and the CLIs have a single import site.
+export { parseGitStatus, branchNameFor, isValidBranchName }
 
 const execFileAsync = promisify(execFile)
-
-/**
- * `YYYY-MM-DD` in local time, or '' when unparseable.
- *
- * Duplicates isoToDateStamp in src/lib/studio/episodeDates.ts, which is
- * TypeScript and therefore not importable here. Five lines is a better trade
- * than restructuring tested code to cross the language boundary.
- *
- * @param {string} iso
- * @returns {string}
- */
-function dateStamp(iso) {
-  if (!iso) return ''
-  const d = new Date(iso)
-  if (Number.isNaN(d.getTime())) return ''
-  const pad = (n) => String(n).padStart(2, '0')
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
-}
-
-/**
- * Parse `git status --porcelain` output.
- *
- * Any output at all means dirty, untracked files included: a stray file travels
- * to the new branch and can end up in the post's PR.
- *
- * @param {string} porcelain
- * @returns {{ dirty: boolean, files: string[] }}
- */
-export function parseGitStatus(porcelain) {
-  const files = []
-  for (const raw of String(porcelain).split('\n')) {
-    if (!raw.trim()) continue
-    // Porcelain v1: two status characters, a space, then the path.
-    const path = raw.slice(3)
-    // Renames read `old -> new`; report the destination.
-    const arrow = path.indexOf(' -> ')
-    files.push(arrow === -1 ? path : path.slice(arrow + 4))
-  }
-  return { dirty: files.length > 0, files }
-}
-
-/**
- * The default branch name for new content, matching names already in use in
- * this repo: `blog-<slug>` and `off-protocol-<YYYY-MM-DD>`.
- *
- * @param {'blog' | 'podcast'} kind
- * @param {{ slug?: string, pubDate?: string }} [opts]
- * @returns {string}
- */
-export function branchNameFor(kind, opts = {}) {
-  const { slug = '', pubDate = '' } = opts
-  if (kind === 'podcast') {
-    const stamp = dateStamp(pubDate)
-    return stamp ? `off-protocol-${stamp}` : `off-protocol-${slug}`
-  }
-  return `blog-${slug}`
-}
-
-/**
- * Whether a string is safe to pass to `git checkout -b`.
- *
- * The name comes from a browser form. It is also passed via execFile with an
- * argv array, so this is defence in depth rather than the only guard.
- *
- * @param {unknown} name
- * @returns {boolean}
- */
-export function isValidBranchName(name) {
-  if (typeof name !== 'string' || name === '') return false
-  if (/\s/.test(name)) return false
-  if (/[~^:?*[\\]/.test(name)) return false
-  if (name.includes('..') || name.includes('@{')) return false
-  if (/^[-/.]/.test(name)) return false
-  if (/[/.]$/.test(name) || name.endsWith('.lock')) return false
-  return true
-}
 
 /**
  * Default runner: execFile with an argv array, never a shell.

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -1,5 +1,23 @@
 import { describe, it, expect } from 'vitest'
-import { parseGitStatus, branchNameFor, isValidBranchName } from './git.mjs'
+import {
+  parseGitStatus,
+  branchNameFor,
+  isValidBranchName,
+  gitState,
+  createBranch,
+} from './git.mjs'
+
+/** Records calls and replies from a script of canned outputs. */
+function fakeRun(replies: Record<string, string | Error>) {
+  const calls: string[][] = []
+  const run = async (command: string, args: string[]) => {
+    calls.push([command, ...args])
+    const reply = replies[args.join(' ')]
+    if (reply instanceof Error) throw reply
+    return reply ?? ''
+  }
+  return { run, calls }
+}
 
 describe('parseGitStatus', () => {
   it('reports a clean tree', () => {
@@ -86,5 +104,69 @@ describe('isValidBranchName', () => {
     ]) {
       expect(isValidBranchName(name), name).toBe(false)
     }
+  })
+})
+
+describe('gitState', () => {
+  it('reports the current branch and a clean tree', async () => {
+    const { run } = fakeRun({
+      'branch --show-current': 'main\n',
+      'status --porcelain': '',
+    })
+    expect(await gitState({ run })).toEqual({
+      branch: 'main',
+      dirty: false,
+      files: [],
+    })
+  })
+
+  it('reports dirty files', async () => {
+    const { run } = fakeRun({
+      'branch --show-current': 'typography\n',
+      'status --porcelain': ' M README.md\n?? scratch.txt',
+    })
+    expect(await gitState({ run })).toEqual({
+      branch: 'typography',
+      dirty: true,
+      files: ['README.md', 'scratch.txt'],
+    })
+  })
+})
+
+describe('createBranch', () => {
+  it('fetches origin/main before checking out, in that order', async () => {
+    const { run, calls } = fakeRun({})
+    await createBranch('blog-my-post', { run })
+    expect(calls).toEqual([
+      ['git', 'fetch', 'origin', 'main'],
+      ['git', 'checkout', '-b', 'blog-my-post', 'origin/main'],
+    ])
+  })
+
+  it('rejects an invalid name before running any command', async () => {
+    const { run, calls } = fakeRun({})
+    await expect(createBranch('bad name', { run })).rejects.toThrow(/invalid/i)
+    expect(calls).toEqual([])
+  })
+
+  it('does not attempt checkout when the fetch fails', async () => {
+    const err = Object.assign(new Error('exit 128'), {
+      stderr: 'fatal: unable to access origin',
+    })
+    const { run, calls } = fakeRun({ 'fetch origin main': err })
+    await expect(createBranch('blog-my-post', { run })).rejects.toThrow(
+      /unable to access origin/,
+    )
+    expect(calls).toEqual([['git', 'fetch', 'origin', 'main']])
+  })
+
+  it('surfaces stderr when the checkout fails', async () => {
+    const err = Object.assign(new Error('exit 128'), {
+      stderr: "fatal: a branch named 'blog-dup' already exists",
+    })
+    const { run } = fakeRun({ 'checkout -b blog-dup origin/main': err })
+    await expect(createBranch('blog-dup', { run })).rejects.toThrow(
+      /already exists/,
+    )
   })
 })

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -172,17 +172,22 @@ describe('createBranch', () => {
 })
 
 describe('client-bundle safety', () => {
-  it('gitNames.mjs imports nothing, so client components can use it', async () => {
-    // The studio editors are 'use client' and import branchNameFor. If this file
-    // ever reaches for node:child_process — as it did when the pure and
-    // effectful helpers lived together — the webpack build fails and the dev
-    // server dies with it. tsc cannot catch that; this can.
-    const { readFileSync } = await import('node:fs')
-    const src = readFileSync(
-      new URL('./gitNames.mjs', import.meta.url),
-      'utf-8',
-    )
-    const imports = src.match(/^\s*import\s.+$/gm) ?? []
-    expect(imports).toEqual([])
-  })
+  // The studio editors are 'use client' and import from these. If any of them
+  // reaches for a node: built-in — as gitNames did when the pure and effectful
+  // helpers lived in one file — the webpack build fails and takes the dev
+  // server with it. tsc cannot catch that; this can.
+  //
+  // Checks for `node:` specifically rather than banning imports outright: these
+  // modules legitimately import each other. That means the check is not
+  // transitive, so every client-safe module must be listed here.
+  const CLIENT_SAFE = ['./gitNames.mjs', './slugs.mjs']
+
+  for (const mod of CLIENT_SAFE) {
+    it(`${mod} pulls in no node: built-ins`, async () => {
+      const { readFileSync } = await import('node:fs')
+      const src = readFileSync(new URL(mod, import.meta.url), 'utf-8')
+      const nodeImports = src.match(/^\s*import\s.*['"]node:.*$/gm) ?? []
+      expect(nodeImports).toEqual([])
+    })
+  }
 })

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -170,3 +170,19 @@ describe('createBranch', () => {
     )
   })
 })
+
+describe('client-bundle safety', () => {
+  it('gitNames.mjs imports nothing, so client components can use it', async () => {
+    // The studio editors are 'use client' and import branchNameFor. If this file
+    // ever reaches for node:child_process — as it did when the pure and
+    // effectful helpers lived together — the webpack build fails and the dev
+    // server dies with it. tsc cannot catch that; this can.
+    const { readFileSync } = await import('node:fs')
+    const src = readFileSync(
+      new URL('./gitNames.mjs', import.meta.url),
+      'utf-8',
+    )
+    const imports = src.match(/^\s*import\s.+$/gm) ?? []
+    expect(imports).toEqual([])
+  })
+})

--- a/src/lib/git.test.ts
+++ b/src/lib/git.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import { parseGitStatus, branchNameFor, isValidBranchName } from './git.mjs'
+
+describe('parseGitStatus', () => {
+  it('reports a clean tree', () => {
+    expect(parseGitStatus('')).toEqual({ dirty: false, files: [] })
+    expect(parseGitStatus('\n  \n')).toEqual({ dirty: false, files: [] })
+  })
+
+  it('lists modified, staged, and untracked paths', () => {
+    const out = [' M src/a.ts', 'M  src/b.ts', '?? scratch.txt'].join('\n')
+    expect(parseGitStatus(out)).toEqual({
+      dirty: true,
+      files: ['src/a.ts', 'src/b.ts', 'scratch.txt'],
+    })
+  })
+
+  it('reports the destination path for renames', () => {
+    expect(parseGitStatus('R  old/a.ts -> new/a.ts')).toEqual({
+      dirty: true,
+      files: ['new/a.ts'],
+    })
+  })
+
+  it('counts untracked files as dirty', () => {
+    // Deliberate: an untracked stray file travels to the new branch and can end
+    // up in the post's PR.
+    expect(parseGitStatus('?? notes.md').dirty).toBe(true)
+  })
+})
+
+describe('branchNameFor', () => {
+  it('names blog branches from the slug', () => {
+    expect(branchNameFor('blog', { slug: 'going-off-protocol' })).toBe(
+      'blog-going-off-protocol',
+    )
+  })
+
+  it('names podcast branches from the publish date', () => {
+    // Matches names already in use: off-protocol-2026-07-23.
+    expect(
+      branchNameFor('podcast', {
+        slug: '2026-07-23-livestream-protocolly-atmoseed',
+        pubDate: '2026-07-23T16:38:42.556Z',
+      }),
+    ).toBe('off-protocol-2026-07-23')
+  })
+
+  it('falls back to the slug when the publish date is unusable', () => {
+    expect(branchNameFor('podcast', { slug: 'my-ep', pubDate: '' })).toBe(
+      'off-protocol-my-ep',
+    )
+    expect(branchNameFor('podcast', { slug: 'my-ep', pubDate: 'nonsense' })).toBe(
+      'off-protocol-my-ep',
+    )
+  })
+})
+
+describe('isValidBranchName', () => {
+  it('accepts ordinary names', () => {
+    for (const name of ['blog-my-post', 'off-protocol-2026-07-28', 'fix/typo']) {
+      expect(isValidBranchName(name), name).toBe(true)
+    }
+  })
+
+  it('rejects names git would refuse or a shell might mangle', () => {
+    for (const name of [
+      '',
+      'has space',
+      'tab\there',
+      'a..b',
+      'a~b',
+      'a^b',
+      'a:b',
+      'a?b',
+      'a*b',
+      'a[b',
+      'a\\b',
+      'a@{b',
+      '-leading',
+      '/leading',
+      '.leading',
+      'trailing/',
+      'trailing.',
+      'thing.lock',
+    ]) {
+      expect(isValidBranchName(name), name).toBe(false)
+    }
+  })
+})

--- a/src/lib/gitNames.mjs
+++ b/src/lib/gitNames.mjs
@@ -1,0 +1,89 @@
+/**
+ * Pure git helpers: string parsing, naming, and validation.
+ *
+ * MUST STAY FREE OF NODE BUILT-INS AND ALL IMPORTS. The studio's editors are
+ * `'use client'` components and import `branchNameFor` from here, so anything
+ * reachable from this file ends up in the browser bundle. Pulling in
+ * `node:child_process` — as an earlier version of this did, by keeping these
+ * functions alongside the effectful ones — fails the webpack build outright and
+ * takes the dev server down with it.
+ *
+ * The effectful side lives in ./git.mjs, which imports this and re-exports it so
+ * server-side callers and the CLIs still have a single import site.
+ */
+
+/**
+ * `YYYY-MM-DD` in local time, or '' when unparseable.
+ *
+ * Duplicates isoToDateStamp in src/lib/studio/episodeDates.ts, which is
+ * TypeScript and therefore not importable here. Five lines is a better trade
+ * than restructuring tested code to cross the language boundary.
+ *
+ * @param {string} iso
+ * @returns {string}
+ */
+function dateStamp(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+/**
+ * Parse `git status --porcelain` output.
+ *
+ * Any output at all means dirty, untracked files included: a stray file travels
+ * to the new branch and can end up in the post's PR.
+ *
+ * @param {string} porcelain
+ * @returns {{ dirty: boolean, files: string[] }}
+ */
+export function parseGitStatus(porcelain) {
+  const files = []
+  for (const raw of String(porcelain).split('\n')) {
+    if (!raw.trim()) continue
+    // Porcelain v1: two status characters, a space, then the path.
+    const path = raw.slice(3)
+    // Renames read `old -> new`; report the destination.
+    const arrow = path.indexOf(' -> ')
+    files.push(arrow === -1 ? path : path.slice(arrow + 4))
+  }
+  return { dirty: files.length > 0, files }
+}
+
+/**
+ * The default branch name for new content, matching names already in use in
+ * this repo: `blog-<slug>` and `off-protocol-<YYYY-MM-DD>`.
+ *
+ * @param {'blog' | 'podcast'} kind
+ * @param {{ slug?: string, pubDate?: string }} [opts]
+ * @returns {string}
+ */
+export function branchNameFor(kind, opts = {}) {
+  const { slug = '', pubDate = '' } = opts
+  if (kind === 'podcast') {
+    const stamp = dateStamp(pubDate)
+    return stamp ? `off-protocol-${stamp}` : `off-protocol-${slug}`
+  }
+  return `blog-${slug}`
+}
+
+/**
+ * Whether a string is safe to pass to `git checkout -b`.
+ *
+ * The name comes from a browser form. It is also passed via execFile with an
+ * argv array, so this is defence in depth rather than the only guard.
+ *
+ * @param {unknown} name
+ * @returns {boolean}
+ */
+export function isValidBranchName(name) {
+  if (typeof name !== 'string' || name === '') return false
+  if (/\s/.test(name)) return false
+  if (/[~^:?*[\\]/.test(name)) return false
+  if (name.includes('..') || name.includes('@{')) return false
+  if (/^[-/.]/.test(name)) return false
+  if (/[/.]$/.test(name) || name.endsWith('.lock')) return false
+  return true
+}

--- a/src/lib/slugs.mjs
+++ b/src/lib/slugs.mjs
@@ -1,0 +1,59 @@
+/**
+ * Slug and date-stamp helpers.
+ *
+ * MUST STAY FREE OF NODE BUILT-INS. The studio's editors are `'use client'`
+ * components and import from here, so anything reachable from this file ends up
+ * in the browser bundle — see the note in ./gitNames.mjs for what that costs.
+ *
+ * Plain JavaScript so the `.mjs` authoring CLIs can share it with the
+ * TypeScript studio.
+ */
+
+/**
+ * Lowercase, hyphen-separated, alphanumerics only.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+export function slugify(text) {
+  return String(text)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+}
+
+/**
+ * `YYYY-MM-DD` in local time, or '' when unparseable.
+ *
+ * Local rather than UTC so the stamp matches the date the author sees in the
+ * publish-date control.
+ *
+ * @param {string} iso
+ * @returns {string}
+ */
+export function dateStamp(iso) {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  const pad = (n) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+/**
+ * The default slug for a new episode: `YYYY-MM-DD-title[-first-guest]`.
+ *
+ * Matches the naming the show already uses (2026-07-22-erin-kissane). Only the
+ * first guest appears — the date and title already identify the episode, and
+ * two or three names make the URL unreadable. Any segment that can't be built
+ * is dropped rather than left as an empty gap.
+ *
+ * @param {{ pubDate?: string, title?: string, guests?: string[] }} [input]
+ * @returns {string}
+ */
+export function episodeSlug(input = {}) {
+  const { pubDate = '', title = '', guests = [] } = input
+  const firstGuest = (guests || []).map((g) => String(g).trim()).filter(Boolean)[0]
+  return [dateStamp(pubDate), slugify(title), firstGuest ? slugify(firstGuest) : '']
+    .filter(Boolean)
+    .join('-')
+}

--- a/src/lib/slugs.test.ts
+++ b/src/lib/slugs.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { slugify, dateStamp, episodeSlug } from './slugs.mjs'
+
+describe('slugify', () => {
+  it('lowercases and hyphenates', () => {
+    expect(slugify('Designing for Uncertainty')).toBe('designing-for-uncertainty')
+  })
+
+  it('collapses punctuation runs and trims edge hyphens', () => {
+    expect(slugify('“Nothing Is Ever Over”')).toBe('nothing-is-ever-over')
+    expect(slugify('A -- B?!')).toBe('a-b')
+  })
+
+  it('is empty for empty input', () => {
+    expect(slugify('')).toBe('')
+  })
+})
+
+describe('dateStamp', () => {
+  it('formats YYYY-MM-DD in local time', () => {
+    // Midday UTC so the calendar day is the same in every plausible TZ.
+    expect(dateStamp('2026-07-31T12:00:00.000Z')).toBe('2026-07-31')
+  })
+
+  it('zero-pads', () => {
+    expect(dateStamp('2026-03-05T12:00:00.000Z')).toBe('2026-03-05')
+  })
+
+  it('is empty for a missing or unparseable value', () => {
+    expect(dateStamp('')).toBe('')
+    expect(dateStamp('nope')).toBe('')
+  })
+})
+
+describe('episodeSlug', () => {
+  it('is date, title, and the first guest', () => {
+    expect(
+      episodeSlug({
+        pubDate: '2026-07-31T21:23:48.929Z',
+        title: 'Designing for Uncertainty',
+        guests: ['Ethan Marcotte'],
+      }),
+    ).toBe('2026-07-31-designing-for-uncertainty-ethan-marcotte')
+  })
+
+  it('omits the guest segment when there are none', () => {
+    expect(
+      episodeSlug({
+        pubDate: '2026-07-31T12:00:00.000Z',
+        title: 'Protocolly Atmoseed',
+        guests: [],
+      }),
+    ).toBe('2026-07-31-protocolly-atmoseed')
+  })
+
+  it('uses only the first guest when there are several', () => {
+    // Two or three guests would make the slug unreadable; the date and title
+    // already identify the episode.
+    expect(
+      episodeSlug({
+        pubDate: '2026-07-31T12:00:00.000Z',
+        title: 'In Our Timeline',
+        guests: ['Paul Frazee', 'Daniel Holmgren'],
+      }),
+    ).toBe('2026-07-31-in-our-timeline-paul-frazee')
+  })
+
+  it('drops the date segment when the publish date is unusable', () => {
+    expect(episodeSlug({ pubDate: '', title: 'No Date', guests: [] })).toBe('no-date')
+  })
+
+  it('is empty when there is nothing to build from', () => {
+    // The caller shows a placeholder instead of a half-formed slug.
+    expect(episodeSlug({ pubDate: '', title: '', guests: [] })).toBe('')
+  })
+
+  it('ignores whitespace-only guest entries', () => {
+    expect(
+      episodeSlug({ pubDate: '2026-07-31T12:00:00.000Z', title: 'T', guests: ['   '] }),
+    ).toBe('2026-07-31-t')
+  })
+})

--- a/src/lib/studio/git.ts
+++ b/src/lib/studio/git.ts
@@ -1,0 +1,17 @@
+import {
+  gitState,
+  createBranch,
+  branchNameFor,
+  isValidBranchName,
+  parseGitStatus,
+} from '@/lib/git.mjs'
+
+// The implementation lives in src/lib/git.mjs so the .mjs authoring CLIs can
+// import it too — see that file for why.
+export { gitState, createBranch, branchNameFor, isValidBranchName, parseGitStatus }
+
+export type GitState = {
+  branch: string
+  dirty: boolean
+  files: string[]
+}

--- a/src/lib/studio/service.test.ts
+++ b/src/lib/studio/service.test.ts
@@ -186,6 +186,58 @@ describe('createPost', () => {
   })
 })
 
+describe('createPost partial writes', () => {
+  it('removes the directory when a write fails', async () => {
+    // The failure has to land *after* mkdir to exercise the rollback: a
+    // duplicate slug or a bad posts.ts anchor both fail earlier, before any
+    // directory exists. Making posts.ts read-only fails the last of the three
+    // writes instead.
+    fs.chmodSync(paths.postsFile, 0o444)
+    try {
+      await expect(
+        createPost(paths, {
+          slug: 'boom',
+          title: 'T',
+          description: 'D',
+          date: 'June 1, 2026',
+          author: 'Jim Ray',
+        }),
+      ).rejects.toThrow()
+    } finally {
+      fs.chmodSync(paths.postsFile, 0o644)
+    }
+    expect(fs.existsSync(path.join(paths.blogDir, 'boom'))).toBe(false)
+  })
+
+  it('keeps the post and returns a warning when authors.json cannot be written', async () => {
+    // A malformed authors.json is plausible; losing a written post over it is not.
+    fs.writeFileSync(paths.authorsFile, 'not json at all')
+    const res = await createPost(paths, {
+      slug: 'kept',
+      title: 'Kept',
+      description: 'D',
+      date: 'June 1, 2026',
+      author: 'Guest Person',
+      authorDid: 'did:plc:guest',
+    })
+    expect(res.slug).toBe('kept')
+    expect(res.warning).toMatch(/authors\.json/i)
+    expect(fs.existsSync(path.join(paths.blogDir, 'kept', 'en.mdx'))).toBe(true)
+    expect(fs.readFileSync(paths.postsFile, 'utf-8')).toContain("slug: 'kept'")
+  })
+
+  it('returns no warning on the happy path', async () => {
+    const res = await createPost(paths, {
+      slug: 'fine',
+      title: 'Fine',
+      description: 'D',
+      date: 'June 1, 2026',
+      author: 'Jim Ray',
+    })
+    expect(res.warning).toBeUndefined()
+  })
+})
+
 describe('read/update/list/delete', () => {
   beforeEach(async () => {
     await createPost(paths, {

--- a/src/lib/studio/service.ts
+++ b/src/lib/studio/service.ts
@@ -180,7 +180,7 @@ export async function publishPost(
 export async function createPost(
   paths: StudioPaths,
   input: CreateInput,
-): Promise<{ slug: string }> {
+): Promise<{ slug: string; warning?: string }> {
   for (const f of ['slug', 'title', 'description', 'date', 'author'] as const) {
     if (!input[f] || !String(input[f]).trim()) {
       throw new Error(`Field "${f}" is required`)
@@ -211,24 +211,40 @@ export async function createPost(
   const nextPostsSrc = prependEntry(postsSrc, entryFor(input.slug, owned))
 
   await fs.mkdir(dir, { recursive: true })
-  await fs.writeFile(path.join(dir, 'page.tsx'), blogPageTsx())
-  await fs.writeFile(path.join(dir, 'en.mdx'), newPostMdx(owned, body))
-  await fs.writeFile(paths.postsFile, nextPostsSrc)
+  try {
+    await fs.writeFile(path.join(dir, 'page.tsx'), blogPageTsx())
+    await fs.writeFile(path.join(dir, 'en.mdx'), newPostMdx(owned, body))
+    await fs.writeFile(paths.postsFile, nextPostsSrc)
+  } catch (err) {
+    // Roll back the partially-created directory so a retry isn't blocked, and so
+    // a failed create never leaves half a post behind. Matches createEpisode.
+    // posts.ts is written last, so a failure never leaves an entry pointing at a
+    // missing directory.
+    await fs.rm(dir, { recursive: true, force: true })
+    throw err
+  }
 
-  // Author DID: add to authors.json when a new author + DID was supplied.
+  // Everything past this point is best-effort: the post exists, so a failure
+  // here is a warning rather than an error. Reporting it as an error would tell
+  // the author the post wasn't created when it was.
+  let warning: string | undefined
   if (input.authorDid) {
-    const authors: AuthorMap = JSON.parse(
-      await fs.readFile(paths.authorsFile, 'utf-8'),
-    )
-    if (!resolveAuthorDid(authors, input.author)) {
-      await fs.writeFile(
-        paths.authorsFile,
-        JSON.stringify(withAuthor(authors, input.author, input.authorDid), null, 2) + '\n',
+    try {
+      const authors: AuthorMap = JSON.parse(
+        await fs.readFile(paths.authorsFile, 'utf-8'),
       )
+      if (!resolveAuthorDid(authors, input.author)) {
+        await fs.writeFile(
+          paths.authorsFile,
+          JSON.stringify(withAuthor(authors, input.author, input.authorDid), null, 2) + '\n',
+        )
+      }
+    } catch (err) {
+      warning = `Post created, but authors.json could not be updated: ${(err as Error).message}`
     }
   }
 
-  return { slug: input.slug }
+  return warning ? { slug: input.slug, warning } : { slug: input.slug }
 }
 
 export async function updatePost(


### PR DESCRIPTION
- **feat(git): pure helpers for status parsing, branch naming, and validation**
- **feat(git): gitState and createBranch with an injectable runner**
- **fix(studio): roll back createPost partial writes; authors.json failure is a warning**
- **feat(studio): dev-only endpoint reporting branch and working-tree state**
- **feat(studio): create routes optionally branch from origin/main first**
- **feat(studio): branch block in the episode create flow**
- **feat(studio): branch block in the blog create flow**
- **fix(studio): keep typed spaces in hosts/guests; default the episode slug**
- **feat(blog,podcast): share one branch flow across both create CLIs**
- **docs(studio): document the branch step in the create flow**
- **add link to labeler update guide (#724)**
- **update to non-draft leaflet for labeler link**
