### PR TITLE
fix(studio): survive a reload without losing the open document or its text

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,27 @@ Each editor has a switch to the other in its sidebar.
   and header fields the form doesn't manage are preserved byte-for-byte.
   **Hand-editing the `.mdx` is fully supported** — the UI is the easy path, the
   raw file is for everything else.
+- **Unsaved work survives a reload, not a closed tab.** The open document's slug
+  is in the URL (`?slug=…`), and a draft of the form is kept in `sessionStorage`,
+  so a full page reload comes back to the same document with your text intact and
+  says so in the action bar, with a **Discard** beside it. Next issues full
+  reloads in dev for reasons that have nothing to do with the studio — opening
+  another localhost tab can be enough — which is what this exists for. A draft is
+  only kept while the form differs from the file, so the message only appears
+  when there was something to recover. Drafts are per document and per tab:
+  switching to another episode and back brings its draft with it, and two tabs on
+  two episodes don't tread on each other. Closing the tab drops the draft, on
+  purpose — a draft that outlived the session would eventually be offered for a
+  file that had moved on since.
+- **A save is refused if the file changed underneath you.** Every load
+  fingerprints the file it read, and every save sends that fingerprint back; if it
+  no longer matches, nothing is written and the editor says so with a **Reload
+  from disk** button. Nothing is ever merged silently — resolving it is the
+  author's call, because the two versions can't be reconciled without knowing
+  which one is wanted. You'll meet this if you hand-edit the `.mdx` while a tab
+  has it open, or from a second tab on the same document. A restored draft carries
+  the fingerprint it was captured with, so it conflicts the same way rather than
+  overwriting a newer file. The CLIs send no fingerprint and stay last-write-wins.
 - **Lists scan the content directory**, so anything you created by hand or with
   the CLI shows up in the sidebar.
 - **Slug is read-only after creation.** To rename, delete and recreate.

--- a/src/app/studio/blog/BlogEditor.tsx
+++ b/src/app/studio/blog/BlogEditor.tsx
@@ -5,6 +5,16 @@ import { useEffect, useState } from 'react'
 // component, so nothing reaching node:child_process may be imported here.
 import { branchNameFor } from '@/lib/gitNames.mjs'
 import { singleLine } from '@/lib/studio/text'
+import { slugFromSearch, searchWithSlug } from '@/lib/studio/editorUrl'
+import {
+  DRAFT_SCHEMA,
+  draftKey,
+  readDraft,
+  writeDraft,
+  clearDraft,
+  isDirty,
+  describeDraft,
+} from '@/lib/studio/draft'
 import { unknownAuthors, isValidDid, type AuthorMap } from '@/lib/studio/authors'
 import type { GitState } from '@/lib/studio/git'
 import { StudioNav } from '../StudioNav'
@@ -15,12 +25,44 @@ type Publish = { ok: boolean; uri?: string; error?: string }
 
 const EMPTY: Owned = { title: '', description: '', date: '', author: '' }
 
+/**
+ * Everything a reload would otherwise lose. Stored as a draft and compared
+ * against what was loaded from disk to tell whether there is anything to keep.
+ *
+ * Excludes what the server owns and the mount refetches — the post list, git
+ * state, authors.json, the OG image, the standard.site URI — and `status`, which
+ * describes the last action rather than the document.
+ *
+ * Bump DRAFT_SCHEMA in @/lib/studio/draft when this shape changes.
+ */
+type Snapshot = {
+  mode: 'new' | 'edit'
+  slug: string
+  owned: Owned
+  body: string
+  authorDids: Record<string, string>
+}
+
 function todayLong(): string {
   return new Date().toLocaleDateString('en-US', {
     month: 'long',
     day: 'numeric',
     year: 'numeric',
   })
+}
+
+/**
+ * Point the address bar at the post this tab has open.
+ *
+ * Everything in this form lives in component state, so a reload — including the
+ * full reloads the dev server issues for reasons unrelated to this tab — used to
+ * lose it and drop back to the new-post form, where the next Save creates a post
+ * rather than updating the one being edited. Same fix, same reasoning, as the
+ * episode editor; see the note on syncUrl there.
+ */
+function syncUrl(slug: string) {
+  const search = searchWithSlug(window.location.search, slug)
+  window.history.replaceState(null, '', window.location.pathname + search)
 }
 
 function slugify(text: string): string {
@@ -57,6 +99,12 @@ export function BlogEditor() {
   const [makeBranch, setMakeBranch] = useState(true)
   const [branchName, setBranchName] = useState('')
   const [dirtyFiles, setDirtyFiles] = useState<string[]>([])
+  // The form as it was last loaded from disk or written to it. A draft is only
+  // kept while the form differs from this, so "unsaved changes" is never a lie.
+  const [baseline, setBaseline] = useState<Snapshot | null>(null)
+  // The status-line message for a draft this tab brought back, and the flag for
+  // the Discard button beside it. Empty when nothing was restored.
+  const [restored, setRestored] = useState('')
 
   async function refreshList() {
     try {
@@ -90,47 +138,182 @@ export function BlogEditor() {
     }
   }
 
+  // The form as it stands. Rebuilt every render; `snapshotKey` is what the draft
+  // effect watches, since the object itself is a new identity each time.
+  const snapshot: Snapshot = { mode, slug, owned, body, authorDids }
+  const snapshotKey = JSON.stringify(snapshot)
+
+  // Which document's draft this form owns. The new-post form keys off '' — the
+  // slug typed into it is contents, not identity.
+  const docSlug = mode === 'edit' ? slug : ''
+
+  function applySnapshot(s: Snapshot) {
+    setMode(s.mode)
+    setSlug(s.slug)
+    setOwned(s.owned)
+    setBody(s.body)
+    setAuthorDids(s.authorDids)
+  }
+
+  function newSnapshot(): Snapshot {
+    return {
+      mode: 'new',
+      slug: '',
+      owned: { ...EMPTY, date: todayLong() },
+      body: '',
+      authorDids: {},
+    }
+  }
+
+  /**
+   * Bring back a draft for `s` on top of what was just loaded from disk.
+   *
+   * The baseline stays as the on-disk state, so the restored form still reads as
+   * changed and keeps its draft until it's saved. The revision comes from the
+   * draft too — a restored draft conflicts with a file that moved on rather than
+   * overwriting it.
+   */
+  function restoreDraft(s: string): boolean {
+    const key = draftKey('blog', s)
+    const draft = readDraft(key, s)
+    if (!draft) return false
+    // The schema version is the real guard, but a hand-edited or truncated draft
+    // shouldn't be able to take the form down. Check what render depends on.
+    const form = draft.form as Partial<Snapshot>
+    if (!form.owned || typeof form.body !== 'string') {
+      clearDraft(key)
+      return false
+    }
+    applySnapshot(form as Snapshot)
+    setRevision(draft.revision)
+    setRestored(describeDraft(draft))
+    return true
+  }
+
+  // Load from disk, then let any draft this tab holds for it come back on top.
+  // Used from the URL on mount and from the post list — but never after a create,
+  // and never from the conflict reload, where discarding the form is exactly what
+  // was asked for.
+  async function openPost(s: string): Promise<boolean> {
+    const ok = await loadPost(s)
+    if (ok) restoreDraft(s)
+    return ok
+  }
+
+  function discardDraft() {
+    clearDraft(draftKey('blog', docSlug))
+    setRestored('')
+  }
+
+  // Throw away what was restored and go back to what's on disk — or to a blank
+  // form, for a post that has no file yet.
+  function discard() {
+    discardDraft()
+    if (mode === 'edit') loadPost(slug)
+    else startNew()
+  }
+
   useEffect(() => {
     refreshList()
     loadGit()
+    // A slug in the URL means this tab already had a post open; restore it from
+    // disk. If it won't load — deleted since, or a hand-edited URL — the form is
+    // already in its new-post state, so only the stale param needs clearing.
+    const open = slugFromSearch(window.location.search)
+    if (open) {
+      const clearIfMissing = (ok?: boolean) => {
+        if (ok) return
+        syncUrl('')
+        setBaseline(snapshot)
+      }
+      openPost(open).then(clearIfMissing).catch(() => clearIfMissing())
+      return
+    }
+    // The initial state already *is* the new-post form, so adopt it as the
+    // baseline rather than reading the clock a second time and risking a form
+    // that reads as changed before anything was typed.
+    setBaseline(snapshot)
+    restoreDraft('')
   }, [])
 
+  // Keep the draft in step with the form, so an unexpected reload has something
+  // to come back to. Debounced only to avoid a write per keystroke — the write
+  // itself is synchronous and the payload is small.
+  useEffect(() => {
+    if (!baseline) return
+    const key = draftKey('blog', docSlug)
+    if (!isDirty(snapshot, baseline)) {
+      clearDraft(key)
+      return
+    }
+    const timer = window.setTimeout(() => {
+      // A draft already holding this exact form is left alone. Rewriting it would
+      // only move `savedAt` forward, and then "unsaved changes from 3:42" would
+      // report the last reload rather than the last edit.
+      const stored = readDraft(key, docSlug)
+      if (stored && !isDirty(snapshot, stored.form)) return
+      writeDraft(key, {
+        v: DRAFT_SCHEMA,
+        slug: docSlug,
+        mode,
+        savedAt: new Date().toISOString(),
+        revision,
+        form: snapshot,
+      })
+    }, 300)
+    return () => window.clearTimeout(timer)
+    // snapshotKey stands in for `snapshot`, which is a fresh object each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [snapshotKey, baseline, docSlug, mode, revision])
+
   function startNew() {
-    setMode('new')
-    setSlug('')
-    setOwned({ ...EMPTY, date: todayLong() })
-    setAuthorDids({})
-    setBody('')
+    // Only the new-post form's own draft goes. A draft for the post being left is
+    // kept on purpose: clicking back to it in the list brings the work back,
+    // which is the whole point of keeping drafts per document.
+    clearDraft(draftKey('blog', ''))
+    setRestored('')
+    syncUrl('')
+    const s = newSnapshot()
+    applySnapshot(s)
+    setBaseline(s)
     setSsiteUri('')
     setOgImage(null)
     setDragging(false)
     setStatus('')
     setRevision('')
     setConflict(false)
-    setAuthorDids({})
     setBranchName('')
     setMakeBranch(true)
     loadGit()
   }
 
-  async function loadPost(s: string) {
+  // Returns whether the post loaded, so the mount effect can tell a stale slug in
+  // the URL from a good one.
+  async function loadPost(s: string): Promise<boolean> {
     const res = await fetch(`/api/studio/blog/${s}`)
     if (!res.ok) {
       setStatus(`Error loading ${s}`)
-      return
+      return false
     }
     const data = await res.json()
-    setMode('edit')
-    setSlug(s)
-    setOwned(data.owned)
-    setAuthorDids({})
-    setBody(data.body)
+    const loaded: Snapshot = {
+      mode: 'edit',
+      slug: s,
+      owned: data.owned,
+      body: data.body,
+      authorDids: {},
+    }
+    applySnapshot(loaded)
+    setBaseline(loaded)
+    setRestored('')
+    syncUrl(s)
     setSsiteUri(data.standardSiteUri || '')
     setOgImage(data.ogImage ?? null)
     setOgVersion((v) => v + 1)
     setRevision(data.revision ?? '')
     setConflict(false)
     setStatus('')
+    return true
   }
 
   // Update the standard.site URI field from a publish result. Publish state is
@@ -169,6 +352,11 @@ export function BlogEditor() {
       // Reveal step 2: load the created post (body placeholder, ssite, og image)
       // from disk, then show a plain save status.
       await loadPost(data.slug)
+      // The post exists now, so the new-post draft has nothing left to recover.
+      // Cleared *after* the load, not before: the create request takes longer
+      // than the draft debounce, so a write scheduled before it started would
+      // otherwise land after the clear and leave a stale draft behind.
+      clearDraft(draftKey('blog', ''))
       applyPublish(data.publish)
       const where = data.branch?.created ? ` on ${data.branch.name}` : ''
       setStatus(data.warning ?? `Created ${data.slug}${where}`)
@@ -192,13 +380,15 @@ export function BlogEditor() {
       if (!res.ok) return setStatus(`Error: ${data.error}`)
       // Smart typography is applied server-side; show the stored strings so the
       // form doesn't keep displaying straight quotes the file no longer has.
-      if (data.owned) {
-        setOwned((o) => ({
-          ...o,
-          title: data.owned.title,
-          description: data.owned.description,
-        }))
-      }
+      const stored: Owned = data.owned
+        ? { ...owned, title: data.owned.title, description: data.owned.description }
+        : owned
+      if (data.owned) setOwned(stored)
+      // What's on disk now is what's on screen, so this becomes the baseline and
+      // the draft has nothing left to recover. authorDids is cleared just below,
+      // so the baseline records it empty.
+      setBaseline({ ...snapshot, owned: stored, authorDids: {} })
+      discardDraft()
       // Adopt the revision this save created, or the next save from this same
       // open tab would conflict with its own write.
       if (data.revision) setRevision(data.revision)
@@ -248,6 +438,9 @@ export function BlogEditor() {
     const res = await fetch(`/api/studio/blog/${slug}`, { method: 'DELETE' })
     const data = await res.json()
     if (!res.ok) return setStatus(`Error: ${data.error}`)
+    // The post is gone; a draft keyed to it would be offered for a document that
+    // no longer exists.
+    clearDraft(draftKey('blog', slug))
     setStatus(`Deleted ${slug}`)
     startNew()
     await refreshList()
@@ -297,7 +490,7 @@ export function BlogEditor() {
             return (
               <li key={p.slug}>
                 <button
-                  onClick={() => loadPost(p.slug)}
+                  onClick={() => openPost(p.slug)}
                   className={
                     'block w-full rounded-md px-2 py-1.5 text-left transition ' +
                     (active
@@ -356,6 +549,24 @@ export function BlogEditor() {
                 {status}
               </span>
             )}
+            {/* A draft this tab brought back after a reload. Says so rather than
+                leaving it ambiguous whether the form reflects the file on disk,
+                and offers the one-click way out. */}
+            {restored && (
+              <span
+                className="flex items-baseline gap-2 text-sm text-neutral-500"
+                aria-live="polite"
+              >
+                {restored}
+                <span className="text-neutral-300">·</span>
+                <button
+                  onClick={discard}
+                  className="underline decoration-neutral-300 underline-offset-4 transition hover:text-neutral-900 hover:decoration-neutral-500"
+                >
+                  Discard
+                </button>
+              </span>
+            )}
             {/* Only offered on a conflict, and it discards the form's edits — so
                 it says so rather than looking like an ordinary refresh. */}
             {conflict && (
@@ -364,6 +575,10 @@ export function BlogEditor() {
                   if (
                     confirm('Reload from disk? Unsaved changes in this form are lost.')
                   ) {
+                    // Reloading from disk is a choice to abandon the form, so the
+                    // draft goes too — otherwise the next reload would hand these
+                    // same edits straight back.
+                    discardDraft()
                     loadPost(slug)
                   }
                 }}

--- a/src/app/studio/podcast/EpisodeEditor.tsx
+++ b/src/app/studio/podcast/EpisodeEditor.tsx
@@ -12,6 +12,16 @@ import {
 import { branchNameFor } from '@/lib/gitNames.mjs'
 import { episodeSlug } from '@/lib/slugs.mjs'
 import { singleLine } from '@/lib/studio/text'
+import { slugFromSearch, searchWithSlug } from '@/lib/studio/editorUrl'
+import {
+  DRAFT_SCHEMA,
+  draftKey,
+  readDraft,
+  writeDraft,
+  clearDraft,
+  isDirty,
+  describeDraft,
+} from '@/lib/studio/draft'
 import { unknownAuthors, isValidDid, type AuthorMap } from '@/lib/studio/authors'
 import {
   EPISODE_FORMATS,
@@ -45,6 +55,27 @@ type Fields = {
   blueskyPostUrl: string
 }
 
+/**
+ * Everything a reload would otherwise lose. Stored as a draft and compared
+ * against what was loaded from disk to tell whether there is anything to keep.
+ *
+ * Excludes what the server owns and the mount refetches — the episode list, git
+ * state, authors.json, the OG image — and `status`, which describes the last
+ * action rather than the document. Audio and OG uploads write to disk as they
+ * happen, so they were never draft state either.
+ *
+ * Bump DRAFT_SCHEMA in @/lib/studio/draft when this shape changes.
+ */
+type Snapshot = {
+  mode: 'new' | 'edit'
+  slug: string
+  fields: Fields
+  body: string
+  hostsText: string
+  guestsText: string
+  authorDids: Record<string, string>
+}
+
 function fmtDuration(totalSeconds: number): string {
   const s = Math.round(totalSeconds)
   const hh = String(Math.floor(s / 3600)).padStart(2, '0')
@@ -59,6 +90,26 @@ function nowDates(): Pick<Fields, 'date' | 'pubDate'> {
   const now = new Date().toISOString()
   return { pubDate: now, date: isoToHumanDate(now) }
 }
+
+/**
+ * Point the address bar at the episode this tab has open.
+ *
+ * Everything in this form lives in component state, so a reload used to lose it
+ * and drop back to the new-episode form — where the date-derived default slug is
+ * non-empty even with no title, so the next Save created a date-named episode
+ * instead of updating the one being edited. The dev server issues full reloads
+ * for reasons that have nothing to do with this tab (another localhost tab
+ * compiling a route is enough), so the open episode has to be recoverable.
+ *
+ * replaceState rather than pushState: this is where the tab already is, not a
+ * navigation, and Back should leave the studio rather than walk an episode
+ * history that no popstate handler is restoring.
+ */
+function syncUrl(slug: string) {
+  const search = searchWithSlug(window.location.search, slug)
+  window.history.replaceState(null, '', window.location.pathname + search)
+}
+
 function emptyFields(nextNumber: number): Fields {
   return {
     episodeNumber: nextNumber,
@@ -111,6 +162,15 @@ export function EpisodeEditor() {
   // Name → DID typed into the prompts below. Kept separate from `fields` because
   // these are not episode data; they end up in authors.json.
   const [authorDids, setAuthorDids] = useState<Record<string, string>>({})
+  // The form as it was last loaded from disk or written to it. A draft is only
+  // kept while the form differs from this, so "unsaved changes" is never a lie.
+  // Null until the form has been loaded or armed once — there is nothing to
+  // compare against before that, and writing a draft then would capture the
+  // placeholder state.
+  const [baseline, setBaseline] = useState<Snapshot | null>(null)
+  // The status-line message for a draft this tab brought back, and the flag for
+  // the Discard button beside it. Empty when nothing was restored.
+  const [restored, setRestored] = useState('')
 
   async function refreshList() {
     try {
@@ -157,48 +217,204 @@ export function EpisodeEditor() {
     }
   }
 
+  // The form as it stands. Rebuilt every render; `snapshotKey` is what the draft
+  // effect watches, since the object itself is a new identity each time.
+  const snapshot: Snapshot = { mode, slug, fields, body, hostsText, guestsText, authorDids }
+  const snapshotKey = JSON.stringify(snapshot)
+
+  // Which document's draft this form owns. The new-episode form keys off '' — the
+  // slug typed into it is contents, not identity.
+  const docSlug = mode === 'edit' ? slug : ''
+
+  function applySnapshot(s: Snapshot) {
+    setMode(s.mode)
+    setSlug(s.slug)
+    setFields(s.fields)
+    setBody(s.body)
+    setHostsText(s.hostsText)
+    setGuestsText(s.guestsText)
+    setAuthorDids(s.authorDids)
+  }
+
+  // A brand-new episode, clock included. Read here rather than during render (see
+  // nowDates) and returned rather than applied, so it can serve as the baseline
+  // as well as the form state.
+  function newSnapshot(): Snapshot {
+    return {
+      mode: 'new',
+      slug: '',
+      fields: { ...emptyFields(nextNumber), ...nowDates() },
+      body: '',
+      hostsText: '',
+      guestsText: '',
+      authorDids: {},
+    }
+  }
+
+  function armNewEpisode(): Snapshot {
+    const s = newSnapshot()
+    applySnapshot(s)
+    setBaseline(s)
+    setRevision('')
+    setBranchName(branchNameFor('podcast', { pubDate: s.fields.pubDate }))
+    return s
+  }
+
+  /**
+   * Bring back a draft for `s` on top of what was just loaded from disk.
+   *
+   * The baseline is deliberately left as the on-disk state, so the restored form
+   * still reads as changed and keeps its draft until it's saved. The revision
+   * comes from the draft too — a restored draft conflicts with a file that moved
+   * on rather than overwriting it.
+   */
+  function restoreDraft(s: string): boolean {
+    const key = draftKey('podcast', s)
+    const draft = readDraft(key, s)
+    if (!draft) return false
+    // The schema version is the real guard, but a hand-edited or truncated draft
+    // shouldn't be able to take the form down. Check what render depends on.
+    const form = draft.form as Partial<Snapshot>
+    if (!form.fields || typeof form.body !== 'string') {
+      clearDraft(key)
+      return false
+    }
+    applySnapshot(form as Snapshot)
+    setRevision(draft.revision)
+    setRestored(describeDraft(draft))
+    return true
+  }
+
+  // Load from disk, then let any draft this tab holds for it come back on top.
+  // Used from the URL on mount and from the episode list — but never after a
+  // create, and never from the conflict reload, where discarding the form is
+  // exactly what was asked for.
+  async function openEpisode(s: string): Promise<boolean> {
+    const ok = await loadEpisode(s)
+    if (ok) restoreDraft(s)
+    return ok
+  }
+
+  function discardDraft() {
+    clearDraft(draftKey('podcast', docSlug))
+    setRestored('')
+  }
+
+  // Throw away what was restored and go back to what's on disk — or to a blank
+  // form, for an episode that has no file yet.
+  function discard() {
+    discardDraft()
+    if (mode === 'edit') loadEpisode(slug)
+    else startNew()
+  }
+
   useEffect(() => {
-    const dates = nowDates()
-    setFields((f) => ({ ...f, ...dates }))
-    setBranchName(branchNameFor('podcast', { pubDate: dates.pubDate }))
     loadGit()
+    // A slug in the URL means this tab already had an episode open. Restore it
+    // from disk instead of arming a new one — and don't touch the date or
+    // episode-number fields on that path, or they would overwrite what
+    // loadEpisode is about to read.
+    const open = slugFromSearch(window.location.search)
+    if (open) {
+      refreshList()
+      // Deleted since, or a hand-edited URL: keep loadEpisode's error on screen,
+      // drop the stale param, and give them a usable new-episode form.
+      const fallBack = (ok?: boolean) => {
+        if (ok) return
+        syncUrl('')
+        armNewEpisode()
+      }
+      openEpisode(open).then(fallBack).catch(() => fallBack())
+      return
+    }
+    armNewEpisode()
+    const restoredNew = restoreDraft('')
     refreshList().then((n) => {
-      if (typeof n === 'number') setFields((f) => ({ ...f, episodeNumber: n }))
+      // The next episode number isn't known until this resolves, so the armed
+      // form and its baseline both start at 1. Patch both, or the form would read
+      // as changed before anything had been typed. A restored draft already has
+      // the number that was being worked on and keeps it.
+      if (restoredNew || typeof n !== 'number') return
+      setFields((f) => ({ ...f, episodeNumber: n }))
+      setBaseline((b) =>
+        b && b.mode === 'new' ? { ...b, fields: { ...b.fields, episodeNumber: n } } : b,
+      )
     })
   }, [])
 
+  // Keep the draft in step with the form, so an unexpected reload has something
+  // to come back to. Debounced only to avoid a write per keystroke — the write
+  // itself is synchronous and the payload is small.
+  useEffect(() => {
+    if (!baseline) return
+    const key = draftKey('podcast', docSlug)
+    if (!isDirty(snapshot, baseline)) {
+      clearDraft(key)
+      return
+    }
+    const timer = window.setTimeout(() => {
+      // A draft already holding this exact form is left alone. Rewriting it would
+      // only move `savedAt` forward, and then "unsaved changes from 3:42" would
+      // report the last reload rather than the last edit.
+      const stored = readDraft(key, docSlug)
+      if (stored && !isDirty(snapshot, stored.form)) return
+      writeDraft(key, {
+        v: DRAFT_SCHEMA,
+        slug: docSlug,
+        mode,
+        savedAt: new Date().toISOString(),
+        revision,
+        form: snapshot,
+      })
+    }, 300)
+    return () => window.clearTimeout(timer)
+    // snapshotKey stands in for `snapshot`, which is a fresh object each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [snapshotKey, baseline, docSlug, mode, revision])
+
   function startNew() {
-    setMode('new')
-    setSlug('')
-    const dates = nowDates()
-    setFields({ ...emptyFields(nextNumber), ...dates })
-    setHostsText('')
-    setGuestsText('')
-    setBody('')
+    // Only the new-episode form's own draft goes. A draft for the episode being
+    // left is kept on purpose: clicking back to it in the list brings the work
+    // back, which is the whole point of keeping drafts per document.
+    clearDraft(draftKey('podcast', ''))
+    setRestored('')
+    syncUrl('')
+    armNewEpisode()
     setOgImage(null)
     setStatus('')
-    setRevision('')
     setConflict(false)
-    setBranchName(branchNameFor('podcast', { pubDate: dates.pubDate }))
     setMakeBranch(true)
     loadGit()
   }
 
-  async function loadEpisode(s: string) {
+  // Returns whether the episode loaded, so the mount effect can fall back to the
+  // new-episode form when the slug in the URL no longer names one.
+  async function loadEpisode(s: string): Promise<boolean> {
     const res = await fetch(`/api/studio/podcast/${s}`)
-    if (!res.ok) return setStatus(`Error loading ${s}`)
+    if (!res.ok) {
+      setStatus(`Error loading ${s}`)
+      return false
+    }
     const data = await res.json()
-    setMode('edit')
-    setSlug(s)
-    setFields(data.fields)
-    setHostsText((data.fields.hosts ?? []).join(', '))
-    setGuestsText((data.fields.guests ?? []).join(', '))
-    setBody(data.body)
+    const loaded: Snapshot = {
+      mode: 'edit',
+      slug: s,
+      fields: data.fields,
+      body: data.body,
+      hostsText: (data.fields.hosts ?? []).join(', '),
+      guestsText: (data.fields.guests ?? []).join(', '),
+      authorDids: {},
+    }
+    applySnapshot(loaded)
+    setBaseline(loaded)
+    setRestored('')
+    syncUrl(s)
     setOgImage(data.ogImage ?? null)
     setOgVersion((v) => v + 1)
     setRevision(data.revision ?? '')
     setConflict(false)
     setStatus('')
+    return true
   }
 
   const setF = <K extends keyof Fields>(k: K, v: Fields[K]) =>
@@ -242,14 +458,20 @@ export function EpisodeEditor() {
     // only those fields back, so edits in progress elsewhere on the form aren't
     // clobbered by the on-disk copy.
     const saved: Partial<Fields> = data.fields ?? {}
-    setFields((f) => ({
-      ...f,
+    const uploaded = {
       audioUrl: saved.audioUrl ?? data.audioUrl,
       audioSizeBytes: saved.audioSizeBytes ?? data.audioSizeBytes,
-      audioMimeType: saved.audioMimeType ?? f.audioMimeType,
       duration: saved.duration ?? duration,
       durationSeconds: saved.durationSeconds ?? durationSeconds,
+    }
+    setFields((f) => ({
+      ...f,
+      ...uploaded,
+      audioMimeType: saved.audioMimeType ?? f.audioMimeType,
     }))
+    // These landed on disk, so they belong in the baseline too — otherwise an
+    // upload alone would leave the form reading as having unsaved changes.
+    setBaseline((b) => (b ? { ...b, fields: { ...b.fields, ...uploaded } } : b))
     // The upload rewrote en.mdx, so the form's base revision is now stale.
     // Adopt the new one or the next save would be refused for no reason.
     if (data.revision) setRevision(data.revision)
@@ -317,6 +539,11 @@ export function EpisodeEditor() {
       }
       if (!res.ok) return setStatus(`Error: ${data.error}`)
       await loadEpisode(data.slug)
+      // The episode exists now, so the new-episode draft has nothing left to
+      // recover. Cleared *after* the load, not before: the create request takes
+      // longer than the draft debounce, so a write scheduled before it started
+      // would otherwise land after the clear and leave a stale draft behind.
+      clearDraft(draftKey('podcast', ''))
       // Recorded DIDs come back in knownAuthors on the next refresh, so the
       // prompts disappear on their own; drop what was typed either way.
       setAuthorDids({})
@@ -346,13 +573,15 @@ export function EpisodeEditor() {
       if (!res.ok) return setStatus(`Error: ${data.error}`)
       // Smart typography is applied server-side; show the stored strings so the
       // form doesn't keep displaying straight quotes the file no longer has.
-      if (data.fields) {
-        setFields((f) => ({
-          ...f,
-          title: data.fields.title,
-          description: data.fields.description,
-        }))
-      }
+      const stored: Fields = data.fields
+        ? { ...fields, title: data.fields.title, description: data.fields.description }
+        : fields
+      if (data.fields) setFields(stored)
+      // What's on disk now is what's on screen, so this becomes the baseline and
+      // the draft has nothing left to recover. authorDids is cleared just below,
+      // so the baseline records it empty.
+      setBaseline({ ...snapshot, fields: stored, authorDids: {} })
+      discardDraft()
       // Adopt the revision this save created, or the next save from this same
       // open tab would conflict with its own write.
       if (data.revision) setRevision(data.revision)
@@ -383,6 +612,9 @@ export function EpisodeEditor() {
     )
     const data = await res.json()
     if (!res.ok) return setStatus(`Error: ${data.error}`)
+    // The episode is gone; a draft keyed to it would be offered for a document
+    // that no longer exists.
+    clearDraft(draftKey('podcast', slug))
     setStatus(data.audioDeleted ? `Deleted ${slug} and its MP3` : `Deleted ${slug}`)
     startNew()
     await refreshList()
@@ -406,7 +638,7 @@ export function EpisodeEditor() {
             return (
               <li key={e.slug}>
                 <button
-                  onClick={() => loadEpisode(e.slug)}
+                  onClick={() => openEpisode(e.slug)}
                   className={'block w-full rounded-md px-2 py-1.5 text-left transition ' + (active ? 'bg-neutral-900/[0.06] text-neutral-900' : 'text-neutral-600 hover:bg-neutral-900/[0.04]')}
                 >
                   <span className="block truncate text-sm">{e.title}</span>
@@ -436,12 +668,31 @@ export function EpisodeEditor() {
           </div>
           <div className="flex items-center gap-4">
             {status && <span className={'text-sm ' + (isError ? 'text-red-600' : 'text-neutral-500')} aria-live="polite">{status}</span>}
+            {/* A draft this tab brought back after a reload. Says so rather than
+                leaving it ambiguous whether the form reflects the file on disk,
+                and offers the one-click way out. */}
+            {restored && (
+              <span className="flex items-baseline gap-2 text-sm text-neutral-500" aria-live="polite">
+                {restored}
+                <span className="text-neutral-300">·</span>
+                <button
+                  onClick={discard}
+                  className="underline decoration-neutral-300 underline-offset-4 hover:text-neutral-900 hover:decoration-neutral-500"
+                >
+                  Discard
+                </button>
+              </span>
+            )}
             {/* Only offered on a conflict, and it discards the form's edits — so
                 it says so rather than looking like an ordinary refresh. */}
             {conflict && (
               <button
                 onClick={() => {
                   if (confirm('Reload from disk? Unsaved changes in this form are lost.')) {
+                    // Reloading from disk is a choice to abandon the form, so the
+                    // draft goes too — otherwise the next reload would hand these
+                    // same edits straight back.
+                    discardDraft()
                     loadEpisode(slug)
                   }
                 }}

--- a/src/lib/studio/draft.test.ts
+++ b/src/lib/studio/draft.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DRAFT_SCHEMA,
+  draftKey,
+  serializeDraft,
+  parseDraft,
+  isDirty,
+  describeDraft,
+} from './draft'
+
+const form = { title: 'The Shinkansen Mindset', body: 'notes', hosts: ['Jim Ray'] }
+
+function envelope(over: Record<string, unknown> = {}) {
+  return {
+    v: DRAFT_SCHEMA,
+    slug: '2026-08-06-shinkansen-mindset',
+    mode: 'edit',
+    savedAt: '2026-08-06T22:42:00.000Z',
+    revision: 'abc123',
+    form,
+    ...over,
+  }
+}
+
+describe('draftKey', () => {
+  it('names a key per kind and slug', () => {
+    expect(draftKey('podcast', '2026-08-06-shinkansen-mindset')).toBe(
+      'studio:podcast:2026-08-06-shinkansen-mindset',
+    )
+  })
+
+  // The new-document form has no slug of its own — the one typed into it is part
+  // of the draft's contents, not its identity, since it changes as you type.
+  it('names the new-document form', () => {
+    expect(draftKey('podcast', '')).toBe('studio:podcast:new')
+    expect(draftKey('blog', '')).toBe('studio:blog:new')
+  })
+
+  it('keeps blog and podcast apart for the same slug', () => {
+    expect(draftKey('blog', 'cobblers-kids')).not.toBe(
+      draftKey('podcast', 'cobblers-kids'),
+    )
+  })
+})
+
+describe('parseDraft', () => {
+  it('round-trips a draft', () => {
+    const parsed = parseDraft(serializeDraft(envelope()), {
+      slug: '2026-08-06-shinkansen-mindset',
+    })
+    expect(parsed?.form).toEqual(form)
+    expect(parsed?.revision).toBe('abc123')
+    expect(parsed?.mode).toBe('edit')
+  })
+
+  it('returns null when there is no draft', () => {
+    expect(parseDraft(null, { slug: 'x' })).toBeNull()
+    expect(parseDraft('', { slug: 'x' })).toBeNull()
+  })
+
+  it('returns null for anything that is not a draft object', () => {
+    expect(parseDraft('not json', { slug: 'x' })).toBeNull()
+    expect(parseDraft('null', { slug: 'x' })).toBeNull()
+    expect(parseDraft('[]', { slug: 'x' })).toBeNull()
+    expect(parseDraft('"a string"', { slug: 'x' })).toBeNull()
+    expect(parseDraft('42', { slug: 'x' })).toBeNull()
+  })
+
+  // The snapshot shape is the contract between what wrote the draft and what
+  // reads it. A draft written by an older build of the studio is discarded rather
+  // than applied to a form whose fields have moved on.
+  it('returns null when the schema version does not match', () => {
+    const stale = serializeDraft(envelope({ v: DRAFT_SCHEMA - 1 }))
+    expect(parseDraft(stale, { slug: '2026-08-06-shinkansen-mindset' })).toBeNull()
+  })
+
+  // Belt to the URL validation's braces: a draft must never be applied to a
+  // different document than the one it was captured from.
+  it('returns null when the draft belongs to another document', () => {
+    const raw = serializeDraft(envelope())
+    expect(parseDraft(raw, { slug: 'cobblers-kids' })).toBeNull()
+    expect(parseDraft(raw, { slug: '' })).toBeNull()
+  })
+
+  it('matches the new-document form on an empty slug', () => {
+    const raw = serializeDraft(envelope({ slug: '', mode: 'new' }))
+    expect(parseDraft(raw, { slug: '' })?.mode).toBe('new')
+  })
+
+  it('returns null for an unknown mode', () => {
+    const raw = serializeDraft(envelope({ mode: 'browsing' }))
+    expect(parseDraft(raw, { slug: '2026-08-06-shinkansen-mindset' })).toBeNull()
+  })
+
+  it('returns null when the form is not an object', () => {
+    for (const bad of ['a string', 42, null, ['an array']]) {
+      const raw = serializeDraft(envelope({ form: bad }))
+      expect(
+        parseDraft(raw, { slug: '2026-08-06-shinkansen-mindset' }),
+      ).toBeNull()
+    }
+  })
+
+  // An absent revision would restore as '', which the server reads as "no
+  // precondition" — the draft would then overwrite a file that had changed on
+  // disk instead of being refused. A draft we can't trust the revision of is not
+  // a draft we can restore.
+  it('returns null when the revision is missing or not a string', () => {
+    for (const bad of [undefined, null, 7, {}]) {
+      const raw = serializeDraft(envelope({ revision: bad }))
+      expect(
+        parseDraft(raw, { slug: '2026-08-06-shinkansen-mindset' }),
+      ).toBeNull()
+    }
+  })
+
+  // A new document has no file yet, so '' is its legitimate revision and has to
+  // survive the round trip.
+  it('keeps an empty revision for a new document', () => {
+    const raw = serializeDraft(envelope({ slug: '', mode: 'new', revision: '' }))
+    expect(parseDraft(raw, { slug: '' })?.revision).toBe('')
+  })
+})
+
+describe('isDirty', () => {
+  it('is false for identical snapshots', () => {
+    expect(isDirty(form, { ...form, hosts: ['Jim Ray'] })).toBe(false)
+  })
+
+  it('is false for empty snapshots', () => {
+    expect(isDirty({}, {})).toBe(false)
+  })
+
+  it('notices an edited string', () => {
+    expect(isDirty(form, { ...form, title: 'The Shinkansen Mindsets' })).toBe(true)
+  })
+
+  // Guests and hosts are ordered — the byline prints them in order, so a reorder
+  // is a real edit, not an equivalent snapshot.
+  it('notices a reordered array', () => {
+    expect(isDirty({ guests: ['a', 'b'] }, { guests: ['b', 'a'] })).toBe(true)
+  })
+
+  it('notices added and removed keys', () => {
+    expect(isDirty({ a: 1 }, { a: 1, b: 2 })).toBe(true)
+    expect(isDirty({ a: 1, b: 2 }, { a: 1 })).toBe(true)
+  })
+
+  // Trailing whitespace in the MDX body is an edit worth keeping: it survives to
+  // the file, and losing it silently is the bug this whole thing exists to stop.
+  it('notices a whitespace-only change', () => {
+    expect(isDirty({ body: 'notes' }, { body: 'notes ' })).toBe(true)
+    expect(isDirty({ body: 'a\nb' }, { body: 'a\n\nb' })).toBe(true)
+  })
+
+  it('notices a change nested in an object', () => {
+    expect(
+      isDirty({ fields: { n: 1, deep: { x: 'a' } } }, { fields: { n: 1, deep: { x: 'b' } } }),
+    ).toBe(true)
+  })
+
+  // The episode-number input is type=number but round-trips through strings; a
+  // loose comparison would call these equal and lose the edit.
+  it('does not confuse a number with its string form', () => {
+    expect(isDirty({ episodeNumber: 14 }, { episodeNumber: '14' })).toBe(true)
+  })
+
+  it('does not confuse null with undefined or with absent', () => {
+    expect(isDirty({ a: null }, { a: undefined })).toBe(true)
+    expect(isDirty({ a: null }, {})).toBe(true)
+  })
+
+  // Emptying the episode-number field can produce NaN. Reporting that as changed
+  // is correct — the form no longer holds what the file does — and it keeps the
+  // draft being written until the field is valid again.
+  it('treats NaN as changed', () => {
+    expect(isDirty({ episodeNumber: NaN }, { episodeNumber: NaN })).toBe(true)
+  })
+})
+
+describe('describeDraft', () => {
+  it('says when the draft was captured', () => {
+    // Built from local parts so the expectation holds in any timezone.
+    const savedAt = new Date(2026, 7, 6, 15, 42).toISOString()
+    expect(describeDraft(envelope({ savedAt }))).toBe(
+      'Restored unsaved changes from 3:42 PM',
+    )
+  })
+
+  it('still says something when the timestamp is unusable', () => {
+    expect(describeDraft(envelope({ savedAt: 'not a date' }))).toBe(
+      'Restored unsaved changes',
+    )
+    expect(describeDraft(envelope({ savedAt: '' }))).toBe(
+      'Restored unsaved changes',
+    )
+  })
+})

--- a/src/lib/studio/draft.ts
+++ b/src/lib/studio/draft.ts
@@ -1,0 +1,181 @@
+/**
+ * Unsaved-work drafts for the studio editors.
+ *
+ * Both editors hold the document being written in component state, so anything
+ * that reloads the tab loses it. Putting the slug in the URL (see ./editorUrl)
+ * brings the right document back; this brings the *text* back with it.
+ *
+ * **sessionStorage, deliberately, not localStorage.** The failure being recovered
+ * from is "this tab reloaded" — the dev server issues full reloads for reasons
+ * that have nothing to do with the studio — and per-tab-surviving-reload is
+ * exactly sessionStorage's lifetime. localStorage is worse twice over: it is
+ * shared between tabs, so two studio tabs would collide on the `new` key and one
+ * tab's save would wipe the other's draft; and its drafts outlive the work, so
+ * you would eventually be offered a draft written before commits made since. The
+ * cost is that closing the tab drops the draft, which is the right trade —
+ * closing a tab is something you meant to do.
+ *
+ * A draft is only written when the form differs from what it was loaded from, so
+ * "unsaved changes" always means there were some.
+ *
+ * MUST STAY FREE OF NODE BUILT-INS. The editors are `'use client'` components, so
+ * everything reachable from here ends up in the browser bundle.
+ */
+
+/**
+ * The snapshot shape is a contract between the build that wrote a draft and the
+ * build that reads it. Bump this whenever an editor's snapshot gains, loses, or
+ * renames a field; older drafts are then discarded instead of being applied to a
+ * form that no longer matches them.
+ */
+export const DRAFT_SCHEMA = 1
+
+export type Draft<T = unknown> = {
+  v: number
+  /** The document this draft belongs to; '' for the new-document form. */
+  slug: string
+  mode: 'new' | 'edit'
+  savedAt: string
+  /**
+   * The revision the form was loaded with, carried so a restored draft still
+   * conflicts with a file that changed on disk rather than overwriting it.
+   */
+  revision: string
+  form: T
+}
+
+/**
+ * Where a document's draft lives.
+ *
+ * The new-document form keys off '' rather than the slug typed into it: that slug
+ * is part of the draft's contents and changes as you type, so it can't also be
+ * its identity.
+ */
+export function draftKey(kind: 'podcast' | 'blog', slug: string): string {
+  return `studio:${kind}:${slug || 'new'}`
+}
+
+export function serializeDraft(draft: unknown): string {
+  return JSON.stringify(draft)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * A usable draft for `slug`, or null.
+ *
+ * Every rejection is a null rather than a throw: a draft is a convenience, and a
+ * corrupt or stale one must degrade to "no draft" instead of taking the editor
+ * down with it.
+ */
+export function parseDraft(
+  raw: string | null | undefined,
+  expected: { slug: string },
+): Draft | null {
+  if (!raw) return null
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return null
+  }
+  if (!isRecord(parsed)) return null
+
+  if (parsed.v !== DRAFT_SCHEMA) return null
+  if (parsed.slug !== expected.slug) return null
+  if (parsed.mode !== 'new' && parsed.mode !== 'edit') return null
+  // An absent revision restores as '', which the server reads as "no
+  // precondition" — the draft would then overwrite a file that had changed
+  // underneath it instead of being refused. Don't restore what we can't trust
+  // the revision of.
+  if (typeof parsed.revision !== 'string') return null
+  if (typeof parsed.savedAt !== 'string') return null
+  if (!isRecord(parsed.form)) return null
+
+  return {
+    v: parsed.v,
+    slug: parsed.slug,
+    mode: parsed.mode,
+    savedAt: parsed.savedAt,
+    revision: parsed.revision,
+    form: parsed.form,
+  }
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return false
+    return a.length === b.length && a.every((v, i) => deepEqual(v, b[i]))
+  }
+  if (isRecord(a) && isRecord(b)) {
+    const keys = Object.keys(a)
+    if (keys.length !== Object.keys(b).length) return false
+    return keys.every(
+      (k) => Object.prototype.hasOwnProperty.call(b, k) && deepEqual(a[k], b[k]),
+    )
+  }
+  return false
+}
+
+/**
+ * Whether a form snapshot differs from the one it was loaded from.
+ *
+ * Structural and strict: `14` is not `'14'`, a reordered guest list is a change,
+ * and so is trailing whitespace in the MDX body. Anything this misses is work
+ * that gets silently dropped, which is the failure being fixed — so it errs
+ * toward reporting a change (NaN, for one, is never equal to itself).
+ */
+export function isDirty(current: unknown, baseline: unknown): boolean {
+  return !deepEqual(current, baseline)
+}
+
+/**
+ * The status-line message for a restored draft.
+ *
+ * Explicit 'en-US' rather than the ambient locale, matching todayLong() in the
+ * blog editor, so the studio reads the same wherever it runs.
+ */
+export function describeDraft(draft: { savedAt: string }): string {
+  const when = new Date(draft.savedAt)
+  if (!draft.savedAt || Number.isNaN(when.getTime())) {
+    return 'Restored unsaved changes'
+  }
+  const time = when.toLocaleTimeString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+  return `Restored unsaved changes from ${time}`
+}
+
+// --- The only part that touches the browser. -------------------------------
+// Kept to three thin wrappers so the logic above stays testable in the node
+// environment. sessionStorage throws when it's disabled or over quota; a draft is
+// a convenience, so every failure degrades to "no drafts" rather than surfacing.
+
+export function readDraft(key: string, slug: string): Draft | null {
+  try {
+    return parseDraft(window.sessionStorage.getItem(key), { slug })
+  } catch {
+    return null
+  }
+}
+
+export function writeDraft(key: string, draft: Draft): void {
+  try {
+    window.sessionStorage.setItem(key, serializeDraft(draft))
+  } catch {
+    // Disabled or full — the editor works as it did before drafts existed.
+  }
+}
+
+export function clearDraft(key: string): void {
+  try {
+    window.sessionStorage.removeItem(key)
+  } catch {
+    // As above.
+  }
+}

--- a/src/lib/studio/editorUrl.test.ts
+++ b/src/lib/studio/editorUrl.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest'
+import { isEditableSlug, slugFromSearch, searchWithSlug } from './editorUrl'
+
+describe('isEditableSlug', () => {
+  it('accepts the slugs the studio actually produces', () => {
+    expect(isEditableSlug('2026-08-06-shinkansen-mindset')).toBe(true)
+    expect(isEditableSlug('cobblers-kids')).toBe(true)
+    expect(isEditableSlug('2024-protocol-roadmap')).toBe(true)
+  })
+
+  it('rejects an empty or missing slug', () => {
+    expect(isEditableSlug('')).toBe(false)
+    expect(isEditableSlug(null)).toBe(false)
+    expect(isEditableSlug(undefined)).toBe(false)
+  })
+
+  // The slug reaches the server as a path segment and is joined onto the
+  // content directory there without further checks, so a slug arriving from the
+  // query string is validated before it is ever fetched.
+  it('rejects path traversal and separators', () => {
+    expect(isEditableSlug('../../../etc/passwd')).toBe(false)
+    expect(isEditableSlug('..')).toBe(false)
+    expect(isEditableSlug('a/b')).toBe(false)
+    expect(isEditableSlug('a\\b')).toBe(false)
+  })
+
+  // `src/app/[locale]/off-protocol/` holds layout.tsx and page.tsx alongside the
+  // episode directories; neither is an episode.
+  it('rejects file names', () => {
+    expect(isEditableSlug('page.tsx')).toBe(false)
+    expect(isEditableSlug('layout.tsx')).toBe(false)
+  })
+
+  it('rejects anything slugify would not have made', () => {
+    expect(isEditableSlug('Cobblers-Kids')).toBe(false)
+    expect(isEditableSlug('two words')).toBe(false)
+    expect(isEditableSlug('-leading-hyphen')).toBe(false)
+    expect(isEditableSlug('emoji-🎧')).toBe(false)
+  })
+})
+
+describe('slugFromSearch', () => {
+  it('reads the slug the editor was opened with', () => {
+    expect(slugFromSearch('?slug=cobblers-kids')).toBe('cobblers-kids')
+  })
+
+  it('works with or without the leading question mark', () => {
+    expect(slugFromSearch('slug=cobblers-kids')).toBe('cobblers-kids')
+  })
+
+  it('returns empty for no query string at all', () => {
+    expect(slugFromSearch('')).toBe('')
+    expect(slugFromSearch('?')).toBe('')
+  })
+
+  it('returns empty when there is no slug param', () => {
+    expect(slugFromSearch('?tab=audio')).toBe('')
+  })
+
+  it('finds the slug among other params', () => {
+    expect(slugFromSearch('?tab=audio&slug=in-our-timeline')).toBe(
+      'in-our-timeline',
+    )
+  })
+
+  // A hand-edited or stale URL must land on the new-episode form rather than
+  // firing a fetch that 404s, or worse, escapes the content directory.
+  it('returns empty for a slug that is not editable', () => {
+    expect(slugFromSearch('?slug=')).toBe('')
+    expect(slugFromSearch('?slug=../../secrets')).toBe('')
+    expect(slugFromSearch('?slug=%2E%2E%2Fsecrets')).toBe('')
+    expect(slugFromSearch('?slug=Not A Slug')).toBe('')
+  })
+})
+
+describe('searchWithSlug', () => {
+  it('adds the slug to an empty query string', () => {
+    expect(searchWithSlug('', 'cobblers-kids')).toBe('?slug=cobblers-kids')
+  })
+
+  it('replaces a slug that is already there', () => {
+    expect(searchWithSlug('?slug=in-our-timeline', 'cobblers-kids')).toBe(
+      '?slug=cobblers-kids',
+    )
+  })
+
+  it('preserves other params', () => {
+    expect(searchWithSlug('?tab=audio', 'cobblers-kids')).toBe(
+      '?tab=audio&slug=cobblers-kids',
+    )
+  })
+
+  // Starting a new episode has nothing to point at yet, so the param goes away
+  // instead of lingering and pointing at the episode that was just left.
+  it('drops the slug when there is none', () => {
+    expect(searchWithSlug('?slug=cobblers-kids', '')).toBe('')
+    expect(searchWithSlug('?tab=audio&slug=cobblers-kids', '')).toBe('?tab=audio')
+  })
+
+  it('refuses to write a slug it would not read back', () => {
+    expect(searchWithSlug('', '../escape')).toBe('')
+  })
+
+  // history.replaceState is called with this on every load, so a no-op has to
+  // stay a no-op rather than accumulating history entries or churning the URL.
+  it('is idempotent', () => {
+    const once = searchWithSlug('', 'cobblers-kids')
+    expect(searchWithSlug(once, 'cobblers-kids')).toBe(once)
+  })
+})

--- a/src/lib/studio/editorUrl.ts
+++ b/src/lib/studio/editorUrl.ts
@@ -1,0 +1,65 @@
+/**
+ * The editor's address bar: which post or episode a studio tab has open.
+ *
+ * Both editors used to keep that in `useState` alone, so anything that reloaded
+ * the tab — a dev-server full reload, ⌘R, a crash — dropped the editor back to
+ * its "new" form. In the episode editor that was worse than losing the text: the
+ * default slug is date-derived, so it stays non-empty with an empty title, and
+ * the next Save created a date-named episode instead of updating the one being
+ * edited.
+ *
+ * Putting the slug in the query string makes the open document addressable, so a
+ * reload restores it from disk rather than guessing.
+ *
+ * MUST STAY FREE OF NODE BUILT-INS. The editors are `'use client'` components,
+ * so everything reachable from here ends up in the browser bundle.
+ */
+
+/**
+ * Whether a string names a post or episode directory this editor may open.
+ *
+ * Slugs are made by `slugify` in src/lib/slugs.mjs — lowercase alphanumerics
+ * separated by single hyphens — and every directory under `[locale]/blog` and
+ * `[locale]/off-protocol` matches. Now that the slug can arrive from the query
+ * string it is checked before use: the API routes interpolate it into a path
+ * with `path.join` and no validation of their own, and those directories also
+ * hold `page.tsx` and `layout.tsx`, which are not content.
+ */
+export function isEditableSlug(slug: string | null | undefined): boolean {
+  if (typeof slug !== 'string') return false
+  return /^[a-z0-9]+(-[a-z0-9]+)*$/.test(slug)
+}
+
+/**
+ * The slug a studio tab was opened with, or '' for the "new" form.
+ *
+ * Anything unusable — absent, empty, hand-mangled, or trying to climb out of the
+ * content directory — reads as '' so the editor starts a new document instead of
+ * fetching something it shouldn't.
+ */
+export function slugFromSearch(search: string): string {
+  const slug = new URLSearchParams(
+    search.startsWith('?') ? search.slice(1) : search,
+  ).get('slug')
+  return isEditableSlug(slug) ? slug! : ''
+}
+
+/**
+ * `search` with `slug` set, or with it removed when there is no slug.
+ *
+ * Other params are preserved and the result is idempotent, because this is
+ * handed to `history.replaceState` on load as well as after every load of a
+ * document.
+ */
+export function searchWithSlug(search: string, slug: string): string {
+  const params = new URLSearchParams(
+    search.startsWith('?') ? search.slice(1) : search,
+  )
+  if (isEditableSlug(slug)) {
+    params.set('slug', slug)
+  } else {
+    params.delete('slug')
+  }
+  const next = params.toString()
+  return next ? `?${next}` : ''
+}


### PR DESCRIPTION
Both editors kept everything in component state, so any reload dropped them
back to their "new" form. The dev server issues full reloads for reasons that
have nothing to do with the studio — opening another localhost tab is enough —
and there was no warning, no URL to come back to, and nothing stored.

In the podcast editor that was worse than losing the text. `defaultSlug` is
date-derived, so it stays non-empty with an empty title: after a reload, Save
took the `mode === 'new'` branch and fired a create the server then refused.
Retyping the title created a duplicate date-named episode, and branched for it.
The blog editor was protected only by accident — `slugify('')` is empty, so its
create bailed on the required-field check.

Two changes, each behind a pure, tested module:

- `editorUrl.ts` puts the open slug in the query string, so a reload reloads
  that document from disk instead of arming a new one. The slug is validated
  before use: it reaches the API routes as a path segment and is joined onto the
  content directory there without checks of their own.

- `draft.ts` keeps a snapshot of the form in sessionStorage, restored silently
  with a note and a Discard in the action bar. sessionStorage rather than
  localStorage because the failure is "this tab reloaded" — localStorage is
  shared between tabs, so two tabs would collide on the `new` key, and its
  drafts outlive the work they belong to.

A draft is written only while the form differs from what it was loaded from, so
"unsaved changes" always means there were some. It carries the revision the
form was loaded with, so a restored draft conflicts with a file that moved on
disk rather than overwriting it — the existing 409 path, not a second one.
Drafts are per document, so switching away and back brings the work with it;
the conflict reload and a successful save clear them, since both mean there is
nothing left to recover.

Tests cover both modules (42 cases). The wiring — two effects and the call
sites per editor — is not covered: it needs a DOM, and adding jsdom for it
wasn't worth a dependency. Verified by hand in the browser.

README documents the tab-close limit, which is the one part that doesn't behave
the way drafts elsewhere do, plus the revision/conflict behaviour it turned out
to have never mentioned.
