### PR TITLE
Replace reference to deprecated React.FormEvent in Next.js OAuth guide

### DIFF
--- a/src/app/[locale]/guides/oauth-tutorial/_snippets/11-login-form.mdx
+++ b/src/app/[locale]/guides/oauth-tutorial/_snippets/11-login-form.mdx
@@ -8,7 +8,7 @@ export function LoginForm() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.SubmitEvent) {
     e.preventDefault();
     setLoading(true);
     setError(null);


### PR DESCRIPTION
As per `@types/react`, [“FormEvent doesn't actually exist”](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/e1f7906509444c6e70ff359060af2ae034dbd369/types/react/index.d.ts#L2087).
It feels, both, more accurate and correct to use the `SubmitEvent` type for the form submission.

This PR updates the type used in the form submission code snippet.