### PR TITLE
chore: stop tracking next-env.d.ts, add a typecheck script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ docs/superpowers
 oauth-test
 src/lexicons
 tsconfig.tsbuildinfo
+next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-import "./.next/types/root-params.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "next typegen && tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:scripts": "node --import tsx --test 'scripts/**/*.test.mjs'",


### PR DESCRIPTION
Next regenerates next-env.d.ts on every dev run and every build, and
writes different contents for each: `next dev` points the imports at
.next/dev/types, `next build` at .next/types. The committed copy was the
build variant, so running the dev server left the file permanently
modified and it flip-flopped between the two commands.

That dirty file also blocked the studio, which refuses to create a
branch when the working tree is not clean (see the gitState check in
src/app/api/studio/blog/route.ts).

Untracking it is safe because Next writes the file unconditionally from
writeAppTypeDeclarations, called by build/type-check.js on build and
setup-dev-bundler.js in dev. Next's own create-next-app template
gitignores it for the same reason.

The one gap that leaves is a bare `tsc --noEmit` on a fresh clone: the
`/// <reference types="next/image-types/global" />` line in the
generated file is what declares image imports, so without it the
SVG imports in Libraries.tsx fail with 11 TS2307 errors. `next typegen`
regenerates the file in about a second, so the new typecheck script
runs it first and works from a clean checkout.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
