### PR TITLE
Add a body-image dropzone to the blog studio

### DIFF
--- a/src/app/api/studio/blog/[slug]/images/[name]/route.ts
+++ b/src/app/api/studio/blog/[slug]/images/[name]/route.ts
@@ -1,0 +1,42 @@
+import { isProd, studioPaths } from '@/lib/studio/paths'
+import { listPostImages } from '@/lib/studio/service'
+import { readFile } from 'node:fs/promises'
+import * as path from 'node:path'
+
+export const runtime = 'nodejs'
+
+const CONTENT_TYPE: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+}
+
+type Ctx = { params: Promise<{ slug: string; name: string }> }
+
+// Serve one inline image's bytes so the studio can show a thumbnail. The post
+// directory is source, not a public URL, so there is nothing to link to.
+export async function GET(_request: Request, { params }: Ctx) {
+  if (isProd()) return new Response('Not found', { status: 404 })
+  const { slug, name } = await params
+  const paths = studioPaths()
+  try {
+    // Serve only what the listing itself reports. That is the traversal guard:
+    // a name is a name in this one directory, never a path to follow.
+    const images = await listPostImages(paths, slug)
+    if (!images.some((i) => i.filename === name)) {
+      return new Response('Not found', { status: 404 })
+    }
+    const ext = name.split('.').pop()!.toLowerCase()
+    const bytes = await readFile(path.join(paths.blogDir, slug, name))
+    return new Response(new Uint8Array(bytes), {
+      headers: {
+        'Content-Type': CONTENT_TYPE[ext] ?? 'application/octet-stream',
+        'Cache-Control': 'no-store',
+      },
+    })
+  } catch {
+    return new Response('Not found', { status: 404 })
+  }
+}

--- a/src/app/api/studio/blog/[slug]/images/route.ts
+++ b/src/app/api/studio/blog/[slug]/images/route.ts
@@ -1,0 +1,55 @@
+import { isProd, studioPaths } from '@/lib/studio/paths'
+import { listPostImages, savePostImage } from '@/lib/studio/service'
+import { imageExtFor, POST_IMAGE_EXTS } from '@/lib/studio/postImages'
+
+export const runtime = 'nodejs'
+
+// Same ceiling as the OG image. These are inline illustrations, not downloads —
+// anything larger is a file that should have been resized before it got here.
+const MAX_BYTES = 8 * 1024 * 1024
+
+type Ctx = { params: Promise<{ slug: string }> }
+
+// The post's inline images, each with the identifier its preamble binds.
+export async function GET(_request: Request, { params }: Ctx) {
+  if (isProd()) return new Response('Not found', { status: 404 })
+  const { slug } = await params
+  try {
+    return Response.json({ slug, images: await listPostImages(studioPaths(), slug) })
+  } catch (err) {
+    return Response.json({ error: (err as Error).message }, { status: 404 })
+  }
+}
+
+// Accept a dropped image, store it beside en.mdx, and add its import.
+export async function POST(request: Request, { params }: Ctx) {
+  if (isProd()) return new Response('Not found', { status: 404 })
+  const { slug } = await params
+  try {
+    const form = await request.formData()
+    const file = form.get('file')
+    if (!(file instanceof File)) {
+      return Response.json({ error: 'No file provided' }, { status: 400 })
+    }
+    if (file.size > MAX_BYTES) {
+      return Response.json(
+        { error: `Image is larger than 8MB (${Math.round(file.size / 1024 / 1024)}MB)` },
+        { status: 400 },
+      )
+    }
+    const ext = imageExtFor(file.name, file.type)
+    if (!ext) {
+      return Response.json(
+        { error: `Unsupported type — use ${POST_IMAGE_EXTS.join(', ').toUpperCase()}` },
+        { status: 400 },
+      )
+    }
+    const bytes = Buffer.from(await file.arrayBuffer())
+    // The revision comes back too: adding the import changed en.mdx, so the
+    // open editor needs it or its next save is refused as a conflict.
+    const saved = await savePostImage(studioPaths(), slug, bytes, file.name, ext)
+    return Response.json({ slug, ...saved })
+  } catch (err) {
+    return Response.json({ error: (err as Error).message }, { status: 400 })
+  }
+}

--- a/src/app/studio/blog/BlogEditor.tsx
+++ b/src/app/studio/blog/BlogEditor.tsx
@@ -16,6 +16,7 @@ import {
   describeDraft,
 } from '@/lib/studio/draft'
 import { unknownAuthors, isValidDid, type AuthorMap } from '@/lib/studio/authors'
+import { imageTag } from '@/lib/studio/postImages'
 import type { GitState } from '@/lib/studio/git'
 import { isBskyPostUrl } from '@/lib/bskyPostUrl'
 import { guardUnload } from '@/lib/studio/unloadGuard'
@@ -30,6 +31,7 @@ type Owned = {
   blueskyPostUrl: string
 }
 type Publish = { ok: boolean; uri?: string; error?: string }
+type PostImage = { filename: string; identifier: string | null }
 
 const EMPTY: Owned = {
   title: '',
@@ -102,6 +104,14 @@ export function BlogEditor() {
   const [ogImage, setOgImage] = useState<string | null>(null)
   const [ogVersion, setOgVersion] = useState(0)
   const [dragging, setDragging] = useState(false)
+  // Inline body images: the files in the post dir, the alt text typed for each
+  // (state only — it ends up in the body, so there is nothing to persist), and
+  // the one whose tag was last copied.
+  const [images, setImages] = useState<PostImage[]>([])
+  const [imageAlts, setImageAlts] = useState<Record<string, string>>({})
+  const [draggingImage, setDraggingImage] = useState(false)
+  const [copiedImage, setCopiedImage] = useState('')
+  const [imageVersion, setImageVersion] = useState(0)
   const [status, setStatus] = useState<string>('')
   // Fingerprint of the file this form was loaded from. Sent with every save so
   // the server can refuse to overwrite changes made since. Empty means "no
@@ -304,6 +314,9 @@ export function BlogEditor() {
     setSsiteUri('')
     setOgImage(null)
     setDragging(false)
+    setImages([])
+    setImageAlts({})
+    setDraggingImage(false)
     setStatus('')
     setRevision('')
     setConflict(false)
@@ -335,6 +348,8 @@ export function BlogEditor() {
     setSsiteUri(data.standardSiteUri || '')
     setOgImage(data.ogImage ?? null)
     setOgVersion((v) => v + 1)
+    setImageAlts({})
+    refreshImages(s)
     setRevision(data.revision ?? '')
     setConflict(false)
     setStatus('')
@@ -460,6 +475,50 @@ export function BlogEditor() {
     setOgImage(data.filename)
     setOgVersion((v) => v + 1)
     setStatus(`OG image saved (${data.filename})`)
+  }
+
+  async function refreshImages(s: string) {
+    try {
+      const res = await fetch(`/api/studio/blog/${s}/images`)
+      if (!res.ok) return setImages([])
+      const data = await res.json()
+      setImages(data.images ?? [])
+      setImageVersion((v) => v + 1)
+    } catch {
+      setImages([])
+    }
+  }
+
+  async function uploadPostImage(file: File) {
+    if (mode !== 'edit') return
+    setStatus('Uploading image…')
+    const form = new FormData()
+    form.append('file', file)
+    const res = await fetch(`/api/studio/blog/${slug}/images`, {
+      method: 'POST',
+      body: form,
+    })
+    const data = await res.json()
+    if (!res.ok) return setStatus(`Error: ${data.error}`)
+    // Writing the import changed en.mdx on disk. Adopt the revision it produced
+    // or the next save is refused as a conflict with our own upload.
+    if (data.revision) setRevision(data.revision)
+    setConflict(false)
+    await refreshImages(slug)
+    setStatus(`Image saved (${data.filename}) — copy its tag into the body`)
+  }
+
+  async function copyImageTag(img: PostImage) {
+    if (!img.identifier) return
+    try {
+      await navigator.clipboard.writeText(
+        imageTag(img.identifier, imageAlts[img.filename] ?? ''),
+      )
+      setCopiedImage(img.filename)
+      window.setTimeout(() => setCopiedImage(''), 1500)
+    } catch {
+      // clipboard blocked — ignore
+    }
   }
 
   async function remove() {
@@ -961,6 +1020,106 @@ export function BlogEditor() {
                   }}
                 />
               </label>
+            </div>
+          )}
+
+          {/* Inline body images */}
+          {mode === 'edit' && (
+            <div className="mt-6">
+              <p className="mb-1.5 text-[0.7rem] font-medium uppercase tracking-[0.18em] text-neutral-400">
+                Body images
+              </p>
+              <label
+                onDragOver={(e) => {
+                  e.preventDefault()
+                  setDraggingImage(true)
+                }}
+                onDragLeave={() => setDraggingImage(false)}
+                onDrop={(e) => {
+                  e.preventDefault()
+                  setDraggingImage(false)
+                  const file = e.dataTransfer.files?.[0]
+                  if (file) uploadPostImage(file)
+                }}
+                className={
+                  'flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed px-4 py-6 text-center transition ' +
+                  (draggingImage
+                    ? 'border-neutral-500 bg-neutral-50'
+                    : 'border-neutral-300 hover:border-neutral-400')
+                }
+              >
+                <span className="text-sm text-neutral-500">
+                  Drag an image here, or click to choose
+                </span>
+                <span className="mt-1 text-xs text-neutral-400">
+                  PNG, JPG, GIF, or WEBP · saved in the post dir, import added for you
+                </span>
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/gif,image/webp"
+                  className="hidden"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0]
+                    if (file) uploadPostImage(file)
+                    e.target.value = ''
+                  }}
+                />
+              </label>
+
+              {images.length > 0 && (
+                <ul className="mt-3 space-y-2">
+                  {images.map((img) => (
+                    <li
+                      key={img.filename}
+                      className="flex items-start gap-3 rounded-lg border border-neutral-200 p-2"
+                    >
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={`/api/studio/blog/${slug}/images/${img.filename}?v=${imageVersion}`}
+                        alt=""
+                        className="h-16 w-16 shrink-0 rounded border border-neutral-200 object-cover"
+                      />
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-mono text-xs text-neutral-500">
+                          {img.filename}
+                        </p>
+                        {img.identifier ? (
+                          <>
+                            <input
+                              value={imageAlts[img.filename] ?? ''}
+                              onChange={(e) =>
+                                setImageAlts((a) => ({
+                                  ...a,
+                                  [img.filename]: e.target.value,
+                                }))
+                              }
+                              placeholder="Alt text — describe the image"
+                              className="mt-1.5 w-full rounded-md border border-neutral-300 px-2 py-1 text-xs text-neutral-800 outline-none focus:border-neutral-500 placeholder:text-neutral-300"
+                            />
+                            <div className="mt-1.5 flex items-center gap-2">
+                              <button
+                                onClick={() => copyImageTag(img)}
+                                className="rounded-md border border-neutral-300 px-2.5 py-1 text-xs font-medium text-neutral-700 transition hover:border-neutral-400 hover:bg-neutral-50"
+                              >
+                                {copiedImage === img.filename ? 'Copied' : 'Copy tag'}
+                              </button>
+                              <code className="truncate font-mono text-[0.7rem] text-neutral-400">
+                                {imageTag(img.identifier, imageAlts[img.filename] ?? '')}
+                              </code>
+                            </div>
+                          </>
+                        ) : (
+                          // No import line: the file was copied into the post
+                          // directory by hand. Dropping it here adds one.
+                          <p className="mt-1.5 text-xs text-neutral-400">
+                            No import yet — drop this file above to add one.
+                          </p>
+                        )}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
           )}
 

--- a/src/lib/studio/postImages.test.ts
+++ b/src/lib/studio/postImages.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from 'vitest'
+import {
+  imageExtFor,
+  sanitizeImageFilename,
+  parsePreambleImports,
+  identifierFor,
+  addPreambleImport,
+  imageTag,
+} from './postImages'
+
+describe('imageExtFor', () => {
+  it('reads the extension from the filename', () => {
+    expect(imageExtFor('chart.PNG', '')).toBe('png')
+    expect(imageExtFor('photo.jpeg', '')).toBe('jpeg')
+    expect(imageExtFor('anim.gif', '')).toBe('gif')
+    expect(imageExtFor('shot.webp', '')).toBe('webp')
+  })
+
+  it('falls back to the MIME type when the name has no usable extension', () => {
+    // A file dropped from some clipboards arrives as "image" with no extension.
+    expect(imageExtFor('image', 'image/png')).toBe('png')
+    expect(imageExtFor('screenshot', 'image/jpeg')).toBe('jpeg')
+  })
+
+  it('rejects types Next cannot import as a static image', () => {
+    expect(imageExtFor('doc.pdf', 'application/pdf')).toBe(null)
+    expect(imageExtFor('logo.svg', 'image/svg+xml')).toBe(null)
+  })
+})
+
+describe('sanitizeImageFilename', () => {
+  it('slugifies the basename and lowercases the extension', () => {
+    expect(sanitizeImageFilename('My Chart.PNG')).toBe('my-chart.png')
+  })
+
+  it('drops punctuation that would need escaping in an import path', () => {
+    expect(sanitizeImageFilename('pds chart (final).jpeg')).toBe('pds-chart-final.jpeg')
+  })
+
+  it('keeps only the final dot as the extension', () => {
+    expect(sanitizeImageFilename('ep.12.final.png')).toBe('ep-12-final.png')
+  })
+
+  it('falls back to a usable name when the basename slugifies to nothing', () => {
+    expect(sanitizeImageFilename('___.png')).toBe('image.png')
+  })
+
+  it('uses the resolved extension when the dropped name has none', () => {
+    // Clipboard drops arrive as a bare "screenshot" with the type in the MIME.
+    expect(sanitizeImageFilename('screenshot', 'jpeg')).toBe('screenshot.jpeg')
+  })
+
+  it('refuses to take over the post’s opengraph-image', () => {
+    // Next reads opengraph-image.* from the post dir; an inline image landing
+    // on that name would silently replace the post's social card.
+    expect(sanitizeImageFilename('opengraph-image.png')).toBe('opengraph-image-2.png')
+  })
+})
+
+describe('parsePreambleImports', () => {
+  it('reads identifier and path from a default import', () => {
+    expect(parsePreambleImports('import pdsesImg from "./pdses.png"\n\n')).toEqual([
+      { identifier: 'pdsesImg', file: './pdses.png' },
+    ])
+  })
+
+  it('reads single-quoted paths too', () => {
+    expect(parsePreambleImports("import banner from './banner.png'\n")).toEqual([
+      { identifier: 'banner', file: './banner.png' },
+    ])
+  })
+
+  it('reads every import, in order', () => {
+    const preamble = [
+      'import banner from "./rpg-actor-banner.png"',
+      'import dashboard from "./dashboard.png"',
+      '',
+      '',
+    ].join('\n')
+    expect(parsePreambleImports(preamble).map((i) => i.identifier)).toEqual([
+      'banner',
+      'dashboard',
+    ])
+  })
+
+  it('ignores named and side-effect imports, which bind no default identifier', () => {
+    const preamble = 'import { Chart } from "./chart"\nimport "./styles.css"\n'
+    expect(parsePreambleImports(preamble)).toEqual([])
+  })
+
+  it('returns nothing for an empty preamble', () => {
+    expect(parsePreambleImports('')).toEqual([])
+  })
+})
+
+describe('identifierFor', () => {
+  it('camelCases the basename', () => {
+    expect(identifierFor('pds-chart.png', [])).toBe('pdsChart')
+  })
+
+  it('leaves a single-word name alone', () => {
+    expect(identifierFor('banner.png', [])).toBe('banner')
+  })
+
+  it('prefixes a name that would start with a digit', () => {
+    // `2026Chart` is not a legal identifier.
+    expect(identifierFor('2026-chart.png', [])).toBe('img2026Chart')
+  })
+
+  it('suffixes a number when the name is already bound', () => {
+    expect(identifierFor('chart.png', ['chart'])).toBe('chart2')
+    expect(identifierFor('chart.png', ['chart', 'chart2'])).toBe('chart3')
+  })
+
+  it('avoids identifiers that would collide with the MDX header export', () => {
+    expect(identifierFor('header.png', [])).toBe('headerImg')
+  })
+
+  it('avoids reserved words', () => {
+    expect(identifierFor('class.png', [])).toBe('classImg')
+  })
+
+  it('falls back to a usable name when the basename yields no letters', () => {
+    expect(identifierFor('___.png', [])).toBe('image')
+  })
+})
+
+describe('addPreambleImport', () => {
+  it('adds the import to an empty preamble, separated from the header', () => {
+    // parseMdxFile splits at `export const header`, so the preamble must end
+    // with the blank line that separates the two.
+    expect(addPreambleImport('', 'pds-chart.png')).toEqual({
+      preamble: 'import pdsChart from "./pds-chart.png"\n\n',
+      identifier: 'pdsChart',
+    })
+  })
+
+  it('appends after the last existing import', () => {
+    const preamble = 'import banner from "./banner.png"\n\n'
+    expect(addPreambleImport(preamble, 'dashboard.png')).toEqual({
+      preamble:
+        'import banner from "./banner.png"\nimport dashboard from "./dashboard.png"\n\n',
+      identifier: 'dashboard',
+    })
+  })
+
+  it('reuses the existing identifier when the file is already imported', () => {
+    // Dropping a file with the same name replaces the bytes in place. A second
+    // import line for the same path would not compile.
+    const preamble = 'import banner from "./banner.png"\n\n'
+    expect(addPreambleImport(preamble, 'banner.png')).toEqual({
+      preamble,
+      identifier: 'banner',
+    })
+  })
+
+  it('picks a free identifier when the obvious one is taken', () => {
+    const preamble = 'import chart from "./old-chart.png"\n\n'
+    expect(addPreambleImport(preamble, 'chart.png').identifier).toBe('chart2')
+  })
+
+  it('keeps preamble content that is not an import', () => {
+    const preamble = '/* hand-written note */\nimport banner from "./banner.png"\n\n'
+    const { preamble: next } = addPreambleImport(preamble, 'chart.png')
+    expect(next).toContain('/* hand-written note */')
+    expect(next).toContain('import chart from "./chart.png"')
+  })
+})
+
+describe('imageTag', () => {
+  it('builds the tag the author pastes into the body', () => {
+    expect(imageTag('pdsChart', 'A chart of PDS growth')).toBe(
+      '<Image src={pdsChart} alt="A chart of PDS growth" />',
+    )
+  })
+
+  it('escapes a double quote in the alt text', () => {
+    // An unescaped quote closes the attribute and breaks the MDX parse.
+    expect(imageTag('cover', 'the "big" one')).toBe(
+      '<Image src={cover} alt="the &quot;big&quot; one" />',
+    )
+  })
+
+  it('escapes an ampersand, which JSX reads as the start of an entity', () => {
+    expect(imageTag('cover', 'this & that')).toBe(
+      '<Image src={cover} alt="this &amp; that" />',
+    )
+  })
+
+  it('still emits an alt attribute when no alt text was typed', () => {
+    // alt="" is a deliberate "decorative"; a missing attribute is a lint error.
+    expect(imageTag('cover', '')).toBe('<Image src={cover} alt="" />')
+  })
+})

--- a/src/lib/studio/postImages.ts
+++ b/src/lib/studio/postImages.ts
@@ -1,0 +1,152 @@
+/**
+ * Inline post images: the filenames they are stored under, the MDX preamble
+ * imports that bind them, and the tag the author pastes into the body.
+ *
+ * A blog post's inline images live beside its `en.mdx` and reach the page as
+ * static imports — `import pdsChart from "./pds-chart.png"` in the preamble,
+ * `<Image src={pdsChart} alt="…" />` in the body. That indirection is what lets
+ * Next size and optimize them, and it is the part that was tedious by hand.
+ *
+ * Pure string work, no Node built-ins: mirrors ./mdxHeader, and keeps the module
+ * safe to import from the studio's client components.
+ */
+import { slugify } from '@/lib/slugs.mjs'
+
+/** Extensions Next can import as a static image and that we accept on upload. */
+export const POST_IMAGE_EXTS = ['png', 'jpg', 'jpeg', 'gif', 'webp'] as const
+export type PostImageExt = (typeof POST_IMAGE_EXTS)[number]
+
+function asExt(value: string | undefined): PostImageExt | null {
+  const v = value?.toLowerCase()
+  return v && (POST_IMAGE_EXTS as readonly string[]).includes(v)
+    ? (v as PostImageExt)
+    : null
+}
+
+/**
+ * The extension to store a dropped file under, from its name or its MIME type.
+ *
+ * SVG is deliberately absent. `next/image` will not derive width and height from
+ * one, so a static import breaks the layout the other images get for free.
+ */
+export function imageExtFor(name: string, type: string): PostImageExt | null {
+  return asExt(name.split('.').pop()) ?? asExt(type.split('/').pop())
+}
+
+/** Basename with the final dot-segment removed: `ep.12.final.png` → `ep.12.final`. */
+function basename(name: string): string {
+  return name.replace(/\.[^./]*$/, '')
+}
+
+/**
+ * The filename a dropped image is stored under: slugified, lowercase extension.
+ *
+ * Slugified rather than taken verbatim because the name ends up inside an import
+ * path in the MDX — a space or a paren there needs escaping, and a stray one
+ * fails the build rather than the upload.
+ *
+ * `ext` overrides the extension read from the name, for drops that arrive with
+ * the type only in the MIME.
+ */
+export function sanitizeImageFilename(name: string, ext?: string): string {
+  const resolved = asExt(ext) ?? imageExtFor(name, '') ?? 'png'
+  let base = slugify(basename(name)) || 'image'
+  // `opengraph-image.*` is Next's social-card convention: a file saved there
+  // replaces the post's card. An inline image must never land on that name.
+  if (base === 'opengraph-image') base = 'opengraph-image-2'
+  return `${base}.${resolved}`
+}
+
+export type PreambleImport = { identifier: string; file: string }
+
+// Default imports only — those are the ones that bind a name the body can use,
+// and the ones whose identifiers a new import must not collide with.
+const IMPORT_RE = /^[ \t]*import\s+([A-Za-z_$][\w$]*)\s+from\s+['"]([^'"]+)['"]/gm
+
+export function parsePreambleImports(preamble: string): PreambleImport[] {
+  const out: PreambleImport[] = []
+  for (const m of preamble.matchAll(IMPORT_RE)) {
+    out.push({ identifier: m[1], file: m[2] })
+  }
+  return out
+}
+
+// `header` is the MDX file's own export; the rest would not parse as a binding.
+const CONFLICTING_NAMES: ReadonlySet<string> = new Set([
+  'header',
+  'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger', 'default',
+  'delete', 'do', 'else', 'enum', 'export', 'extends', 'false', 'finally',
+  'for', 'function', 'if', 'import', 'in', 'instanceof', 'new', 'null',
+  'return', 'super', 'switch', 'this', 'throw', 'true', 'try', 'typeof',
+  'var', 'void', 'while', 'with', 'yield', 'let', 'static', 'await',
+])
+
+function camelCase(slug: string): string {
+  const [first = '', ...rest] = slug.split('-').filter(Boolean)
+  return first + rest.map((w) => w[0].toUpperCase() + w.slice(1)).join('')
+}
+
+/**
+ * The identifier bound to an image, derived from its filename.
+ *
+ * `pds-chart.png` → `pdsChart`, matching what the posts written by hand use.
+ * `taken` is every identifier the preamble already binds, so a second `chart`
+ * becomes `chart2` rather than shadowing the first.
+ */
+export function identifierFor(filename: string, taken: Iterable<string>): string {
+  let name = camelCase(slugify(basename(filename))) || 'image'
+  // A leading digit is not a legal identifier, and a reserved word is not a
+  // legal binding — both get decorated rather than rejected.
+  if (/^\d/.test(name)) name = `img${name[0].toUpperCase()}${name.slice(1)}`
+  if (CONFLICTING_NAMES.has(name)) name = `${name}Img`
+  const used = new Set(taken)
+  if (!used.has(name)) return name
+  let n = 2
+  while (used.has(`${name}${n}`)) n++
+  return `${name}${n}`
+}
+
+/**
+ * Add the import for `filename` to an MDX preamble.
+ *
+ * Idempotent by path: re-uploading a file with the same name replaces the bytes
+ * in place, and a second import of the same path would not compile — so an
+ * already-imported file returns its existing identifier and an untouched
+ * preamble.
+ *
+ * The result always ends with a blank line. `parseMdxFile` splits the file at
+ * `export const header`, and MDX requires that separation or the header stops
+ * being an ESM export.
+ */
+export function addPreambleImport(
+  preamble: string,
+  filename: string,
+): { preamble: string; identifier: string } {
+  const imports = parsePreambleImports(preamble)
+  const file = `./${filename}`
+  const existing = imports.find((i) => i.file === file)
+  if (existing) return { preamble, identifier: existing.identifier }
+
+  const identifier = identifierFor(
+    filename,
+    imports.map((i) => i.identifier),
+  )
+  const lines = preamble.split('\n')
+  let last = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (/^[ \t]*import\s/.test(lines[i])) last = i
+  }
+  lines.splice(last + 1, 0, `import ${identifier} from "${file}"`)
+  return { preamble: `${lines.join('\n').trimEnd()}\n\n`, identifier }
+}
+
+/** JSX reads a bare `&` as the start of an entity and a bare `"` as the end of
+ * the attribute; both have to be escaped or the post stops parsing. */
+function escapeAttribute(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+}
+
+/** The tag the author copies into the body. */
+export function imageTag(identifier: string, alt: string): string {
+  return `<Image src={${identifier}} alt="${escapeAttribute(alt)}" />`
+}

--- a/src/lib/studio/service.test.ts
+++ b/src/lib/studio/service.test.ts
@@ -10,6 +10,8 @@ import {
   deletePost,
   findOgImage,
   saveOgImage,
+  listPostImages,
+  savePostImage,
   type StudioPaths,
 } from './service'
 import { RevisionConflictError } from './revision'
@@ -490,4 +492,127 @@ it('writes blueskyPostUrl on update, keeps it out of posts.ts, and removes it wh
     revision: withUrl.revision,
   })
   expect(fs.readFileSync(mdxPath, 'utf-8')).not.toContain('blueskyPostUrl')
+})
+
+describe('post images', () => {
+  const PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47])
+  const GIF = Buffer.from([0x47, 0x49, 0x46, 0x38])
+
+  async function makePost(slug = 'hello') {
+    await createPost(paths, {
+      slug,
+      title: 'Hello',
+      description: 'Desc',
+      date: 'June 1, 2026',
+      author: 'Jim Ray',
+      body: 'The body.\n',
+    })
+    return slug
+  }
+
+  const mdxFor = (slug: string) =>
+    fs.readFileSync(path.join(paths.blogDir, slug, 'en.mdx'), 'utf-8')
+
+  it('writes the image into the post directory', async () => {
+    const slug = await makePost()
+    const { filename } = await savePostImage(paths, slug, PNG, 'My Chart.PNG')
+    expect(filename).toBe('my-chart.png')
+    const written = fs.readFileSync(path.join(paths.blogDir, slug, 'my-chart.png'))
+    expect(written.equals(PNG)).toBe(true)
+  })
+
+  it('adds the import to the MDX preamble and reports the identifier', async () => {
+    const slug = await makePost()
+    const { identifier } = await savePostImage(paths, slug, PNG, 'pds-chart.png')
+    expect(identifier).toBe('pdsChart')
+    expect(mdxFor(slug)).toContain('import pdsChart from "./pds-chart.png"')
+  })
+
+  it('leaves the header and body untouched', async () => {
+    // The editor may hold unsaved body edits; adding an import must not disturb
+    // what is on disk beyond the preamble, or a later save conflicts with it.
+    const slug = await makePost()
+    const before = mdxFor(slug)
+    await savePostImage(paths, slug, PNG, 'chart.png')
+    const after = mdxFor(slug)
+    expect(after.endsWith(before.slice(before.indexOf('export const header')))).toBe(true)
+  })
+
+  it('reads back through readPost, header intact', async () => {
+    const slug = await makePost()
+    await savePostImage(paths, slug, PNG, 'chart.png')
+    const post = await readPost(paths, slug)
+    expect(post.owned.title).toBe('Hello')
+    expect(post.body.trim()).toBe('The body.')
+  })
+
+  it('returns a revision the still-open editor can save against', async () => {
+    // Writing the import changes the file, so the revision the form loaded with
+    // is stale. Without a fresh one, the next save is refused as a conflict.
+    const slug = await makePost()
+    const { revision } = await savePostImage(paths, slug, PNG, 'chart.png')
+    await updatePost(paths, slug, {
+      owned: { title: 'Hello', description: 'Desc', date: 'June 1, 2026', author: 'Jim Ray', blueskyPostUrl: '' },
+      body: 'Edited.\n',
+      revision,
+    })
+    expect(mdxFor(slug)).toContain('Edited.')
+  })
+
+  it('replaces the bytes and reuses the identifier on a same-name re-upload', async () => {
+    const slug = await makePost()
+    const first = await savePostImage(paths, slug, PNG, 'chart.png')
+    const second = await savePostImage(paths, slug, GIF, 'chart.png')
+    expect(second.identifier).toBe(first.identifier)
+    const mdx = mdxFor(slug)
+    expect(mdx.match(/import chart from/g)).toHaveLength(1)
+    const written = fs.readFileSync(path.join(paths.blogDir, slug, 'chart.png'))
+    expect(written.equals(GIF)).toBe(true)
+  })
+
+  it('gives a second image with a colliding name its own identifier', async () => {
+    const slug = await makePost()
+    await savePostImage(paths, slug, PNG, 'chart.png')
+    const second = await savePostImage(paths, slug, GIF, 'chart.gif')
+    expect(second.identifier).toBe('chart2')
+  })
+
+  it('refuses a post that does not exist', async () => {
+    await expect(savePostImage(paths, 'nope', PNG, 'chart.png')).rejects.toThrow(
+      /not found/i,
+    )
+  })
+
+  it('lists images with the identifier each one is bound to', async () => {
+    const slug = await makePost()
+    await savePostImage(paths, slug, PNG, 'pds-chart.png')
+    await savePostImage(paths, slug, GIF, 'banner.gif')
+    expect(await listPostImages(paths, slug)).toEqual([
+      { filename: 'banner.gif', identifier: 'banner' },
+      { filename: 'pds-chart.png', identifier: 'pdsChart' },
+    ])
+  })
+
+  it('omits the opengraph image, which is not an inline image', async () => {
+    const slug = await makePost()
+    await saveOgImage(paths.blogDir, slug, PNG, 'png')
+    await savePostImage(paths, slug, PNG, 'chart.png')
+    expect(await listPostImages(paths, slug)).toEqual([
+      { filename: 'chart.png', identifier: 'chart' },
+    ])
+  })
+
+  it('lists an image dropped in by hand, with no identifier yet', async () => {
+    // A file copied into the post dir outside the studio has no import line.
+    const slug = await makePost()
+    fs.writeFileSync(path.join(paths.blogDir, slug, 'by-hand.png'), PNG)
+    expect(await listPostImages(paths, slug)).toEqual([
+      { filename: 'by-hand.png', identifier: null },
+    ])
+  })
+
+  it('lists nothing for a post with no images', async () => {
+    const slug = await makePost()
+    expect(await listPostImages(paths, slug)).toEqual([])
+  })
 })

--- a/src/lib/studio/service.ts
+++ b/src/lib/studio/service.ts
@@ -25,6 +25,12 @@ import { fileRevision, assertRevision } from './revision'
 import { applyAuthorDids } from './authorsFile'
 import { blogPageTsx } from './templates'
 import { smartenTitleAndDescription } from './smartText'
+import {
+  POST_IMAGE_EXTS,
+  sanitizeImageFilename,
+  parsePreambleImports,
+  addPreambleImport,
+} from './postImages'
 
 export type StudioPaths = {
   blogDir: string
@@ -160,6 +166,85 @@ export async function saveOgImage(
   const filename = `opengraph-image.${ext}`
   await fs.writeFile(path.join(postDir, filename), bytes)
   return { filename }
+}
+
+export type PostImage = { filename: string; identifier: string | null }
+
+// True for a file the post's body could import as an inline image. The
+// opengraph-image is excluded: Next reads it as the post's social card, and it
+// is managed by its own dropzone.
+function isInlineImage(name: string): boolean {
+  if (name.startsWith('opengraph-image.')) return false
+  const ext = name.split('.').pop()?.toLowerCase()
+  return !!ext && (POST_IMAGE_EXTS as readonly string[]).includes(ext)
+}
+
+/**
+ * The post's inline images, each paired with the identifier its preamble binds.
+ *
+ * `identifier` is null for an image with no import line — a file copied into the
+ * post directory by hand. It is listed rather than hidden, because an image the
+ * studio can't see is exactly the one an author would go looking for.
+ */
+export async function listPostImages(
+  paths: StudioPaths,
+  slug: string,
+): Promise<PostImage[]> {
+  const postDir = path.join(paths.blogDir, slug)
+  if (!existsSync(postDir)) throw new Error(`Post not found: ${slug}`)
+  const names = (await fs.readdir(postDir)).filter(isInlineImage).sort()
+
+  const mdxPath = path.join(postDir, 'en.mdx')
+  let byFile = new Map<string, string>()
+  if (existsSync(mdxPath)) {
+    try {
+      const { preamble } = parseMdxFile(await fs.readFile(mdxPath, 'utf-8'))
+      byFile = new Map(
+        parsePreambleImports(preamble).map((i) => [i.file, i.identifier]),
+      )
+    } catch {
+      // An unparseable header is the editor's problem to report, not a reason
+      // to hide the files that are plainly sitting there.
+    }
+  }
+  return names.map((filename) => ({
+    filename,
+    identifier: byFile.get(`./${filename}`) ?? null,
+  }))
+}
+
+/**
+ * Store an inline image in the post directory and bind it in the MDX preamble.
+ *
+ * Returns the identifier the body should reference and a fresh `revision`:
+ * writing the import changes en.mdx, so the revision the open editor loaded
+ * with is stale, and its next save would be refused as a conflict.
+ *
+ * Only the preamble is touched. The editor may be holding unsaved body edits,
+ * and rewriting the body from disk would quietly undo them.
+ */
+export async function savePostImage(
+  paths: StudioPaths,
+  slug: string,
+  bytes: Buffer,
+  name: string,
+  ext?: string,
+): Promise<{ filename: string; identifier: string; revision: string }> {
+  const postDir = path.join(paths.blogDir, slug)
+  const mdxPath = path.join(postDir, 'en.mdx')
+  if (!existsSync(mdxPath)) throw new Error(`Post not found: ${slug}`)
+
+  // Parse before writing anything: a header this can't read means no import can
+  // be added, and an image with no import is just litter in the post directory.
+  const parsed = parseMdxFile(await fs.readFile(mdxPath, 'utf-8'))
+  const filename = sanitizeImageFilename(name, ext)
+  const { preamble, identifier } = addPreambleImport(parsed.preamble, filename)
+
+  await fs.writeFile(path.join(postDir, filename), bytes)
+  const serialized = serializeMdxFile({ ...parsed, preamble })
+  await fs.writeFile(mdxPath, serialized)
+
+  return { filename, identifier, revision: fileRevision(serialized) }
 }
 
 export type PublishResult = { ok: boolean; uri?: string; error?: string }


### PR DESCRIPTION
Inline images in a post reach the page as static imports: a line in the
MDX preamble binds the file, and the body references the identifier. That
import was the part you had to write by hand, and getting it wrong fails
the build rather than the upload.

Drop an image into the new Body images zone and it lands beside en.mdx,
the import is written for you, and the list below hands you the
<Image> tag to paste into the body — with an alt-text field, because an
alt attribute you mean to fill in later is one you don't.

Details worth knowing:

- Re-dropping the same name replaces the bytes and reuses the identifier.
  A second import of the same path would not compile.
- A file copied into the post dir by hand is listed with no identifier and
  a hint that dropping it here adds its import.
- opengraph-image.png dropped here is saved as opengraph-image-2.png. Next
  reads that name as the post's social card, and an inline image must not
  silently replace it.
- The upload rewrites en.mdx, so it returns a fresh revision the open
  editor adopts — otherwise the next save conflicts with the upload
  itself. Only the preamble is touched; unsaved body edits are safe.
- SVG is not accepted: next/image will not derive dimensions from one, so
  a static import breaks the layout the other images get for free.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
