### PR TITLE
Fix code in lexicon guide

### DIFF
--- a/src/app/[locale]/guides/lexicon/_snippets/follow-schema-example.mdx
+++ b/src/app/[locale]/guides/lexicon/_snippets/follow-schema-example.mdx
@@ -8,6 +8,7 @@
       "description": "A social follow",
       "record": {
         "type": "object",
+        "key": "any",
         "required": ["subject", "createdAt"],
         "properties": {
           "subject": { "type": "string" },

--- a/src/app/[locale]/guides/lexicon/_snippets/sdk-call-ts.mdx
+++ b/src/app/[locale]/guides/lexicon/_snippets/sdk-call-ts.mdx
@@ -1,3 +1,3 @@
 ```tsx
-client.call(app.bsky.actor.getProfile, {})
+client.call(com.example.getProfile, {})
 ```


### PR DESCRIPTION
Fix the sample code inconsistency in the [lexicon guide](https://atproto.com/guides/lexicon).

* the NSID used in the SDK call example
* [`key` field](https://atproto.com/specs/lexicon#record) missing in lexicon sample